### PR TITLE
Remove permalink on index.md

### DIFF
--- a/pages/gsoc/index.md
+++ b/pages/gsoc/index.md
@@ -2,7 +2,6 @@
 layout: col-sidebar
 title: GSoC
 tags: gsoc
-permalink: gsoc
 ---
 
 # OWASP GSoC Information


### PR DESCRIPTION
It seems using a permalink on index.md breaks linking for other things. 
(Edit/PR done via github web interface.)