### PR TITLE
Remove header tag from leadin

### DIFF
--- a/pages/password-special-characters.md
+++ b/pages/password-special-characters.md
@@ -8,7 +8,7 @@ permalink: /password-special-characters
 
 ---
 
-## Password special characters is a selection of punctuation characters that are present on standard US keyboard and frequently used in passwords.
+Password special characters is a selection of punctuation characters that are present on standard US keyboard and frequently used in passwords.
 
 | Character | Name | Unicode
 | :---: | :---: | :---: |


### PR DESCRIPTION
The lead-in doesn't need to appear like a header, in fact it looks junky on the www2 site when rendered as such.

![image](https://user-images.githubusercontent.com/7570458/69367904-216a4980-0c67-11ea-8607-3a50ed7a7012.png)
