### PR TITLE
Fix 'File Listing' Sorting

### DIFF
--- a/index.md
+++ b/index.md
@@ -27,7 +27,7 @@ Include the following front matter in your file (for examples, see pages/passwor
 
 ## File Listing
 
-{% assign pages = site.pages | sort: 'name' | where_exp: "page", "page.path contains 'pages/'" | where_exp: "page", "page.name != 'index.md'" | where_exp: "page": "page.name != 'info.md'"%}
+{% assign pages = site.pages | sort: 'page.title' | where_exp: "page", "page.path contains 'pages/'" | where_exp: "page", "page.name != 'index.md'" | where_exp: "page": "page.name != 'info.md'"%}
 <ul>
 {% for page in pages %}
        <li><a href='/www-community{{ page.url }}'>{{ page.title }}</a>{% if page.author %} by {{ page.author }}{% endif %}</li>

--- a/index.md
+++ b/index.md
@@ -27,7 +27,7 @@ Include the following front matter in your file (for examples, see pages/passwor
 
 ## File Listing
 
-{% assign pages = site.pages | sort: 'page.title' | where_exp: "page", "page.path contains 'pages/'" | where_exp: "page", "page.name != 'index.md'" | where_exp: "page": "page.name != 'info.md'"%}
+{% assign pages = site.pages | sort: 'title' | where_exp: "page", "page.path contains 'pages/'" | where_exp: "page", "page.name != 'index.md'" | where_exp: "page": "page.name != 'info.md'"%}
 <ul>
 {% for page in pages %}
        <li><a href='/www-community{{ page.url }}'>{{ page.title }}</a>{% if page.author %} by {{ page.author }}{% endif %}</li>


### PR DESCRIPTION
Currently uses `name` how this seems to be URL or Path, which results in some incorrectness:
![image](https://user-images.githubusercontent.com/7570458/76042006-9c5b2580-5f21-11ea-8c7b-e870139e6595.png)

Changed to `page.title` since that's what's actually displayed (at L33). @hblankenship I wasn't sure if I needed to maintain the single quotes and if the proper element is `title` or `page.title` let me know, I'm happy to tweak it.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>