### PR TITLE
Link & Grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-OWASP Community Pages is a place where OWASP can accept community contributions for security-related content. To contribute, go to the repository for this site. Go into the pages folder and create a new file. Save and commit the file.
+[OWASP Community Pages](https://owasp.org/www-community/) are a place where OWASP can accept community contributions for security-related content. To contribute, go to the repository for this site. Go into the pages folder and create a new file. Save and commit the file.
 
 Include the following front matter in your file (for examples, see pages/password-special-characters.md in this repository):
 


### PR DESCRIPTION
Add a link to the actual website, just for convenience. Correct minor grammar issue.