### PR TITLE
Fix mistake from previous PR

### DIFF
--- a/pages/Slow_Down_Online_Guessing_Attacks_with_Device_Cookies.md
+++ b/pages/Slow_Down_Online_Guessing_Attacks_with_Device_Cookies.md
@@ -181,7 +181,7 @@ threat:
 <tr class="header">
 <th style="width:20%">Threat</th>
 <th style="width:40%">Threat Details</th>
-<thstyle="width:40%">Mitigation</th>
+<th style="width:40%">Mitigation</th>
 </tr>
 </thead>
 <tbody>


### PR DESCRIPTION
A missing space in a `th` tag was causing a rendering issue.
![image](https://user-images.githubusercontent.com/7570458/76099504-327e6280-5f99-11ea-8813-1a94ed82320e.png)

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>