### PR TITLE
Fix 'Embedding Null Code' title and amend body text

### DIFF
--- a/pages/attacks/Embedding_Null_Code.md
+++ b/pages/attacks/Embedding_Null_Code.md
@@ -2,8 +2,8 @@
 
 title: Embedding Null Code
 layout: col-sidebar
-author:
-contributors:
+author: Nsrav
+contributors: Till Maas, ADubhlaoich
 tags: attacks
 auto-migrated: 1
 permalink: /attacks/Embedding_Null_Code
@@ -13,11 +13,11 @@ permalink: /attacks/Embedding_Null_Code
 ## Description
 
 The Embedding NULL Bytes/characters technique exploits applications that
-don’t properly handle postfix NULL terminators. It is used as a
-technique to perform other attack such as directory browsing, path
-traversal, SQL injection, execution of arbitrary code, and others. It
-can be found in lots of vulnerable applications and there are lots of exploits
-available to abuse systems.
+don’t properly handle postfix NULL terminators. This technique can be used 
+to perform other attacks such as directory browsing, path traversal, SQL 
+injection, execution of arbitrary code, and others. It can be found in lots 
+of vulnerable applications and there are lots of exploits available to 
+abuse systems.
 
 This technique includes several variations to represent the postfix NULL
 terminator:
@@ -25,15 +25,14 @@ terminator:
 `PATH%00`  
 `PATH[0x00]`  
 `PATH[alternate representation of NULL character]`  
-`%00`  
+`<script></script>%00`  
 
 ## Examples
 
 ### PHP Script
 
-The following example shows the use of this technique to modify
-a URL and access arbitrary files on a filesystem due a PHP script
-vulnerability.
+The following example shows the use of this technique to modify a URL and 
+access arbitrary files on a filesystem due a PHP script vulnerability.
 
 `$whatever = addslashes($_REQUEST['whatever']);`  
 `include("/path/to/program/" . $whatever . "/header.htm");`
@@ -48,11 +47,11 @@ UNIX password file:
 Another attacks consists of exploitating buffer overflow in ActiveX components
  (pdf.ocx) to allow remote code execution.
 
-The attack occurs  when a link is requested as follows:
+The attack occurs when a link is requested as follows:
 
 `GET /some_dir/file.pdf.pdf%00[long string] HTTP/1.1`  
 
-This exploit can be used on against a web server that truncates the request at 
+This exploit can be used against a web server that truncates the request at 
 the null byte (%00), such as Microsoft IIS and Netscape Enterprise web servers. 
 Though the requested URI is truncated when locating the file, the full string 
 is still passed to the Adobe ActiveX component. It then triggers a buffer 
@@ -60,7 +59,8 @@ overflow within RTLHeapFree(), allowing an attacker to overwrite arbitrary
 memory.
 
 It can be performed by adding malicious content to the end of any embedded link 
-that references a Microsoft IIS or Netscape Enterprise web server. 
+that references a Microsoft IIS or Netscape Enterprise web server.  
+
 ## External References
 
 <http://capec.mitre.org/data/definitions/52.html>

--- a/pages/attacks/Embedding_Null_Code.md
+++ b/pages/attacks/Embedding_Null_Code.md
@@ -1,6 +1,6 @@
 ---
 
-title: Emedding Null Code
+title: Embedding Null Code
 layout: col-sidebar
 author:
 contributors:
@@ -14,65 +14,53 @@ permalink: /attacks/Embedding_Null_Code
 
 The Embedding NULL Bytes/characters technique exploits applications that
 don’t properly handle postfix NULL terminators. It is used as a
-technique to perform other attacks, like directory browsing, path
-traversal, SQL injection, execution of arbitrary code, among others. It
-can be found lots of vulnerable applications and exploits available to
-abuse systems using this technique.
+technique to perform other attack such as directory browsing, path
+traversal, SQL injection, execution of arbitrary code, and others. It
+can be found in lots of vulnerable applications and there are lots of exploits
+available to abuse systems.
 
 This technique includes several variations to represent the postfix NULL
 terminator:
 
-`PATH%00`
-`PATH[0x00]`
-`PATH[alternate representation of NULL character]`
+`PATH%00`  
+`PATH[0x00]`  
+`PATH[alternate representation of NULL character]`  
+`%00`  
 
-<script>
+## Examples
 
-</script>
+### PHP Script
 
-%00
+The following example shows the use of this technique to modify
+a URL and access arbitrary files on a filesystem due a PHP script
+vulnerability.
 
-## Example
-
-### Example1 – PHP Script
-
-In the following example, it’s shown the use of this technique to modify
-an URL and access arbitrary files on a filesystem due a vulnerability on
-PHP script.
-
-`$whatever = addslashes($_REQUEST['whatever']);`
+`$whatever = addslashes($_REQUEST['whatever']);`  
 `include("/path/to/program/" . $whatever . "/header.htm");`
 
-By manipulating the URL using postfix NULL bytes, one can have access to
+By manipulating the URL using postfix NULL bytes, one can access the
 UNIX password file:
 
 `http://vuln.example.com/phpscript.php?whatever=../../../etc/passwd%00`
 
-### Example2 – Adobe PDF ActiveX Attack
+### Adobe PDF ActiveX Attack
 
-Another know attack, consists in the exploitation of buffer overflow in
-the ActiveX component (pdf.ocx) that allows remote execution arbitrary
-code.
+Another attacks consists of exploitating buffer overflow in ActiveX components
+ (pdf.ocx) to allow remote code execution.
 
-The problem happens when a link is requested as:
+The attack occurs  when a link is requested as follows:
 
-`GET /some_dir/file.pdf.pdf%00[long string] HTTP/1.1`
+`GET /some_dir/file.pdf.pdf%00[long string] HTTP/1.1`  
 
-In this case, the request must be made to a web server that truncates
-the request at the null byte (%00), as Microsoft IIS and Netscape
-Enterprise web servers. Though the requested URI is truncated for the
-purposes of locating the file, the long string is still passed to the
-Adobe ActiveX component. This component triggers a buffers overflow
-within RTLHeapFree() allowing for an attacker to overwrite an arbitrary
-word in memory.
+This exploit can be used on against a web server that truncates the request at 
+the null byte (%00), such as Microsoft IIS and Netscape Enterprise web servers. 
+Though the requested URI is truncated when locating the file, the full string 
+is still passed to the Adobe ActiveX component. It then triggers a buffer 
+overflow within RTLHeapFree(), allowing an attacker to overwrite arbitrary
+memory.
 
-This attack can be performed by adding malicious content to the end of
-any embedded link and referencing any Microsoft IIS or Netscape
-Enterprise web server. It is not necessary to establish a malicious web
-site to execute this attack.
-
-For more details about this attack, see External References topics.
-
+It can be performed by adding malicious content to the end of any embedded link 
+that references a Microsoft IIS or Netscape Enterprise web server. 
 ## External References
 
 <http://capec.mitre.org/data/definitions/52.html>


### PR DESCRIPTION
I was catching up on OWASP news and noticed the new website - this fixes a typo in a page title, though while I was making the change I also re-phrased a lot of the wording on the page, as it was unclear or redundant.

I also attempted to fix some of the spacing issues with the preformatted code examples, as they appeared to be missing proper linebreaks. I'm willing to do a lot of this for other pages and also clear out all of the existing issues in the repository.