### PR TITLE
fix: avoid smart rendering

### DIFF
--- a/pages/attacks/Comment_Injection_Attack.md
+++ b/pages/attacks/Comment_Injection_Attack.md
@@ -52,10 +52,10 @@ records will be received as a query response.
 
 Sequences that may be used to comment queries:
 
-  - MySQL:*\#*, *--*
-  - MS SQL: *--*
-  - MS Access: *%00* (**hack\!**)
-  - Oracle: *--*
+  - MySQL:`#`, `--`
+  - MS SQL: `--`
+  - MS Access: `%00` (**hack\!**)
+  - Oracle: `--`
 
 **Null byte:**
 


### PR DESCRIPTION
The markdown renderer used by OWASP website is configured to use "smart rendering", eg. transforming quotes in smart quotes or in this case transforming double dash `--` into a long dash `–`.

Example:
![image](https://user-images.githubusercontent.com/16578570/82765632-c7665e80-9e18-11ea-9030-60594a92617d.png)

But of course when talking about SQL injection double dash and a long dash is not the same thing. 

The best would be to disable the smart rendering feature but in the meanwhile as changed the italic surrounding of the payloads by inline code block to keep the original verbatim display.