### PR TITLE
Add semgrep to Source Code Analysis Tools

### DIFF
--- a/pages/Source_Code_Analysis_Tools.md
+++ b/pages/Source_Code_Analysis_Tools.md
@@ -169,6 +169,10 @@ every effort to correct this information.</b>
   - [RIPS](http://rips-scanner.sourceforge.net/) - RIPS Open Source is a
     static source code analyzer for vulnerabilities in PHP web
     applications. Please see notes on the sourceforge.net site.
+  - [Semgrep](https://github.com/returntocorp/semgrep) - A fast, lightweight
+    static analysis tool with an intuitive rule syntax that lets you search code
+    like you’d write it. Scans source code, no compilation required. Supports
+    Python, JavaScript, Golang, Java, C, Ruby, and more languages on the way.
   - [ShiftLeft Scan](https://github.com/ShiftLeftSecurity/sast-scan) - Scan is a free open-source DevSecOps platform for detecting security issues in source code and dependencies. It supports a broad range of languages and CI/CD pipelines.
   - [Sink Tank](https://discotek.ca/sinktank.xhtml) - Byte code static
     code analyzer for performing source/sink (taint) analysis.


### PR DESCRIPTION
Add a brief blurb about semgrep (https://github.com/returntocorp/semgrep) to the list of source code analysis tools.