### PR TITLE
Brand change

### DIFF
--- a/_data/vulnerability_scanning_tools.yml
+++ b/_data/vulnerability_scanning_tools.yml
@@ -38,7 +38,8 @@
   owner: Arachni	
   license: Free for most use cases	
   platforms: Most platforms supported
-- title: beSECURE (Formally: AVDS)
+- title: beSECURE (formerly: AVDS)
+
   url: https://www.beyondsecurity.com/
   owner: Beyond Security	
   license: Commercial / Free (Limited Capability)

--- a/_data/vulnerability_scanning_tools.yml
+++ b/_data/vulnerability_scanning_tools.yml
@@ -38,8 +38,8 @@
   owner: Arachni	
   license: Free for most use cases	
   platforms: Most platforms supported
-- title: AVDS
-  url: https://www.scanmyserver.com/
+- title: beSECURE (Formally: AVDS)
+  url: https://www.beyondsecurity.com/
   owner: Beyond Security	
   license: Commercial / Free (Limited Capability)
   platforms: SaaS


### PR DESCRIPTION
Our product AVDS has a name change, to beSECURE
The link provided is for our free version, a better location is our main page which has a separate page for the Commercial and Free version