### PR TITLE
Removed False Content

### DIFF
--- a/pages/attacks/cross-site-request-forgery.md
+++ b/pages/attacks/cross-site-request-forgery.md
@@ -16,9 +16,7 @@ auto-migrated: 1
 
 Cross-Site Request Forgery (CSRF) is an attack that forces an end user
 to execute unwanted actions on a web application in which they're
-currently authenticated. CSRF attacks specifically target state-changing
-requests, not theft of data, since the attacker has no way to see the
-response to the forged request. With a little help of social engineering
+currently authenticated. With a little help of social engineering
 (such as sending a link via email or chat), an attacker may trick the
 users of a web application into executing actions of the attacker's
 choosing. If the victim is a normal user, a successful CSRF attack can


### PR DESCRIPTION
the content removed is not always true. Imagine a scenario (that I have personally seen in the real world) where an XHR request is made to a user-settings endpoint that accepts CORS from *. The response will be accessible by the requesting JavaScript.