### PR TITLE
Add Crashtest Security to List of Vulnerability Scanning Tools

### DIFF
--- a/_data/vulnerability_scanning_tools.yml
+++ b/_data/vulnerability_scanning_tools.yml
@@ -63,6 +63,11 @@
   owner: Contrast Security
   license: Commercial / Free (Full featured for 1 App)
   platforms: SaaS or On-Premises
+- title: Crashtest Security
+  url: https://crashtest-security.com
+  owner: Crashtest Security
+  license: Commercial
+  platforms: SaaS or On-Premises
 - title: Detectify
   url: https://detectify.com/
   owner: Detectify


### PR DESCRIPTION
Crashtest Security is missing in the List of Vulnerability Scanning Tools here: https://owasp.org/www-community/Vulnerability_Scanning_Tools

This PR adds the corresponding information.