### PR TITLE
Nitpick - incorrect capitalisation for Edgescan

### DIFF
--- a/_data/tools.json
+++ b/_data/tools.json
@@ -153,9 +153,9 @@
       "type": "DAST"
    },
    {
-      "title": "edgescan",
+      "title": "Edgescan",
       "url": "https://www.edgescan.com/",
-      "owner": "edgescan",
+      "owner": "Edgescan",
       "license": "Commercial",
       "platforms": "SaaS",
       "note": null,


### PR DESCRIPTION
Changed to match brand guidelines (available at https://landing.edgescan.com/press)