### PR TITLE
Update xss-filter-evasion-cheatsheet.md

### DIFF
--- a/pages/xss-filter-evasion-cheatsheet.md
+++ b/pages/xss-filter-evasion-cheatsheet.md
@@ -4,7 +4,7 @@ layout: col-sidebar
 title: XSS Filter Evasion Cheat Sheet
 author: Jim Manico
 contributors: Abdullah Hussam, Michael McCabe, Luke Plant, Randomm, David Shaw, ALange, Matt Tesauro, Adam Caudill, Anandu,
-              DhirajMishra, Ono, Bill Sempf, Dan Wallis, Peter Mosmans, Dominique Righetto
+              DhirajMishra, Ono, Bill Sempf, Dan Wallis, Peter Mosmans, Dominique Righetto, Agit Kaplan
 tags: XSS, Cheat Sheets
 permalink: /xss-filter-evasion-cheatsheet
 ---
@@ -848,6 +848,49 @@ Extra dot for absolute DNS:
 Assuming `http://www.google.com/` is programmatically replaced with nothing). I actually used a similar attack vector against a several separate real world XSS filters by using the conversion filter itself (here is an example) to help create the attack vector (IE: `java&\#x09;script:` was converted into `java	script:`, which renders in IE, Netscape 8.1+ in secure site mode and Opera):
 
     <A HREF="http://www.google.com/ogle.com/">XSS</A>
+
+
+
+
+## Assisting XSS with HTTP Parameter Pollution
+
+Assume a content sharing flow on a web site is implemented as below. There is a "Content" page which includes some content provided by users and this page also includes a link to "Share" page which enables a user choose his/her favourite social sharing platform to share on it. Developers HTML attribute encoded "title" parameter in "Content" page to prevent from XSS but for some reasons they didn't URL encoded this parameter to prevent from HTTP Parameter Pollution. And also they thought as content_type's value is a constant and it will always be integer as a result of this they didn't encode or validate content_type in "Share" page.
+
+**Content page source code:**
+
+    <a href="/Share?content_type=1&title=<%=Encode.forHtmlAttribute(untrusted content title)%>">Share</a>
+
+**Share page source code:**
+    
+    <script>
+    var contentType = <%=Request.getParameter("content_type")%>;
+    var title = "<%=Encode.forJavaScript(request.getParameter("title"))%>";
+    ...
+    //some user agreement and sending to server logic might be here
+    ...
+    </script>
+
+**Content page output:**  
+In this case if attacker set untrusted content title as “This is a regular title&content_type=1;alert(1)” the link in "Content" page would be this:
+    
+    <a href="/share?content_type=1&title=This is a regular title&amp;content_type=1;alert(1)">Share</a>
+
+**Share page output:**  
+And in share page output could be this:
+    
+    <script>
+    var contentType = 1; alert(1);
+    var title = "This is a regular title";
+    …
+    //some user agreement and sending to server logic might be here
+    …
+    </script>
+
+As a result, in this example main flaw is using content_type in "Share" page without proper encoding or validation, but HTTP Parameter Pollution could increase impact of the  XSS flaw by promoting it from a reflected XSS to a stored XSS. (Submitted by Agit Kaplan)
+
+
+
+
 
 ## Character escape sequences
 

--- a/pages/xss-filter-evasion-cheatsheet.md
+++ b/pages/xss-filter-evasion-cheatsheet.md
@@ -855,7 +855,7 @@ Assume a content sharing flow on a web site is implemented as below. There is a 
 
 ### Content page source code
 
-    <a href="/Share?content_type=1&title=<%=Encode.forHtmlAttribute(untrusted content title)%>">Share</a>
+`a href="/Share?content_type=1&title=<%=Encode.forHtmlAttribute(untrusted content title)%>">Share</a>`
 
 ### Share page source code
     

--- a/pages/xss-filter-evasion-cheatsheet.md
+++ b/pages/xss-filter-evasion-cheatsheet.md
@@ -872,7 +872,7 @@ In this case if attacker set untrusted content title as “This is a regular tit
     
 `<a href="/share?content_type=1&title=This is a regular title&amp;content_type=1;alert(1)">Share</a>`
 
-**Share page output:**  
+### Share page output
 And in share page output could be this:
     
     <script>

--- a/pages/xss-filter-evasion-cheatsheet.md
+++ b/pages/xss-filter-evasion-cheatsheet.md
@@ -853,7 +853,7 @@ Assuming `http://www.google.com/` is programmatically replaced with nothing). I 
 
 Assume a content sharing flow on a web site is implemented as below. There is a "Content" page which includes some content provided by users and this page also includes a link to "Share" page which enables a user choose their favorite social sharing platform to share it on. Developers HTML encoded the "title" parameter in the "Content" page to prevent against XSS but for some reasons they didn't URL encoded this parameter to prevent from HTTP Parameter Pollution. Finally they decide that since content_type's value is a constant and will always be integer, they didn't encode or validate the content_type in the "Share" page.
 
-**Content page source code:**
+### Content page source code
 
     <a href="/Share?content_type=1&title=<%=Encode.forHtmlAttribute(untrusted content title)%>">Share</a>
 

--- a/pages/xss-filter-evasion-cheatsheet.md
+++ b/pages/xss-filter-evasion-cheatsheet.md
@@ -857,7 +857,7 @@ Assume a content sharing flow on a web site is implemented as below. There is a 
 
     <a href="/Share?content_type=1&title=<%=Encode.forHtmlAttribute(untrusted content title)%>">Share</a>
 
-**Share page source code:**
+### Share page source code
     
     <script>
     var contentType = <%=Request.getParameter("content_type")%>;

--- a/pages/xss-filter-evasion-cheatsheet.md
+++ b/pages/xss-filter-evasion-cheatsheet.md
@@ -885,11 +885,6 @@ var title = "This is a regular title";
 </script>
 
 As a result, in this example the main flaw is trusting the content_type in the "Share" page without proper encoding or validation. HTTP Parameter Pollution could increase impact of the XSS flaw by promoting it from a reflected XSS to a stored XSS.
-
-
-
-
-
 ## Character escape sequences
 
 All the possible combinations of the character "\<" in HTML and JavaScript. Most of these won't render out of the box, but many of them can get rendered in certain circumstances as seen above.

--- a/pages/xss-filter-evasion-cheatsheet.md
+++ b/pages/xss-filter-evasion-cheatsheet.md
@@ -870,7 +870,7 @@ Assume a content sharing flow on a web site is implemented as below. There is a 
 **Content page output:**  
 In this case if attacker set untrusted content title as “This is a regular title&content_type=1;alert(1)” the link in "Content" page would be this:
     
-    <a href="/share?content_type=1&title=This is a regular title&amp;content_type=1;alert(1)">Share</a>
+`<a href="/share?content_type=1&title=This is a regular title&amp;content_type=1;alert(1)">Share</a>`
 
 **Share page output:**  
 And in share page output could be this:

--- a/pages/xss-filter-evasion-cheatsheet.md
+++ b/pages/xss-filter-evasion-cheatsheet.md
@@ -859,13 +859,14 @@ Assume a content sharing flow on a web site is implemented as below. There is a 
 
 ### Share page source code
     
-    <script>
-    var contentType = <%=Request.getParameter("content_type")%>;
-    var title = "<%=Encode.forJavaScript(request.getParameter("title"))%>";
-    ...
-    //some user agreement and sending to server logic might be here
-    ...
-    </script>
+```js
+<script>
+var contentType = <%=Request.getParameter("content_type")%>;
+var title = "<%=Encode.forJavaScript(request.getParameter("title"))%>";
+...
+//some user agreement and sending to server logic might be here
+...
+</script>
 
 **Content page output:**  
 In this case if attacker set untrusted content title as “This is a regular title&content_type=1;alert(1)” the link in "Content" page would be this:

--- a/pages/xss-filter-evasion-cheatsheet.md
+++ b/pages/xss-filter-evasion-cheatsheet.md
@@ -849,9 +849,6 @@ Assuming `http://www.google.com/` is programmatically replaced with nothing). I 
 
     <A HREF="http://www.google.com/ogle.com/">XSS</A>
 
-
-
-
 ## Assisting XSS with HTTP Parameter Pollution
 
 Assume a content sharing flow on a web site is implemented as below. There is a "Content" page which includes some content provided by users and this page also includes a link to "Share" page which enables a user choose his/her favourite social sharing platform to share on it. Developers HTML attribute encoded "title" parameter in "Content" page to prevent from XSS but for some reasons they didn't URL encoded this parameter to prevent from HTTP Parameter Pollution. And also they thought as content_type's value is a constant and it will always be integer as a result of this they didn't encode or validate content_type in "Share" page.

--- a/pages/xss-filter-evasion-cheatsheet.md
+++ b/pages/xss-filter-evasion-cheatsheet.md
@@ -884,7 +884,7 @@ var title = "This is a regular title";
 …
 </script>
 
-As a result, in this example main flaw is using content_type in "Share" page without proper encoding or validation, but HTTP Parameter Pollution could increase impact of the  XSS flaw by promoting it from a reflected XSS to a stored XSS. (Submitted by Agit Kaplan)
+As a result, in this example the main flaw is trusting the content_type in the "Share" page without proper encoding or validation. HTTP Parameter Pollution could increase impact of the XSS flaw by promoting it from a reflected XSS to a stored XSS.
 
 
 

--- a/pages/xss-filter-evasion-cheatsheet.md
+++ b/pages/xss-filter-evasion-cheatsheet.md
@@ -868,7 +868,7 @@ var title = "<%=Encode.forJavaScript(request.getParameter("title"))%>";
 ...
 </script>
 
-**Content page output:**  
+### Content page output
 In this case if attacker set untrusted content title as “This is a regular title&content_type=1;alert(1)” the link in "Content" page would be this:
     
 `<a href="/share?content_type=1&title=This is a regular title&amp;content_type=1;alert(1)">Share</a>`

--- a/pages/xss-filter-evasion-cheatsheet.md
+++ b/pages/xss-filter-evasion-cheatsheet.md
@@ -858,7 +858,7 @@ Assume a content sharing flow on a web site is implemented as below. There is a 
 `a href="/Share?content_type=1&title=<%=Encode.forHtmlAttribute(untrusted content title)%>">Share</a>`
 
 ### Share page source code
-    
+
 ```js
 <script>
 var contentType = <%=Request.getParameter("content_type")%>;
@@ -867,13 +867,16 @@ var title = "<%=Encode.forJavaScript(request.getParameter("title"))%>";
 //some user agreement and sending to server logic might be here
 ...
 </script>
+```
 
 ### Content page output
+
 In this case if attacker set untrusted content title as “This is a regular title&content_type=1;alert(1)” the link in "Content" page would be this:
     
 `<a href="/share?content_type=1&title=This is a regular title&amp;content_type=1;alert(1)">Share</a>`
 
 ### Share page output
+
 And in share page output could be this:
     
 ```js
@@ -884,8 +887,10 @@ var title = "This is a regular title";
 //some user agreement and sending to server logic might be here
 …
 </script>
+```
 
 As a result, in this example the main flaw is trusting the content_type in the "Share" page without proper encoding or validation. HTTP Parameter Pollution could increase impact of the XSS flaw by promoting it from a reflected XSS to a stored XSS.
+
 ## Character escape sequences
 
 All the possible combinations of the character "\<" in HTML and JavaScript. Most of these won't render out of the box, but many of them can get rendered in certain circumstances as seen above.

--- a/pages/xss-filter-evasion-cheatsheet.md
+++ b/pages/xss-filter-evasion-cheatsheet.md
@@ -875,13 +875,14 @@ In this case if attacker set untrusted content title as “This is a regular tit
 ### Share page output
 And in share page output could be this:
     
-    <script>
-    var contentType = 1; alert(1);
-    var title = "This is a regular title";
-    …
-    //some user agreement and sending to server logic might be here
-    …
-    </script>
+```js
+<script>
+var contentType = 1; alert(1);
+var title = "This is a regular title";
+…
+//some user agreement and sending to server logic might be here
+…
+</script>
 
 As a result, in this example main flaw is using content_type in "Share" page without proper encoding or validation, but HTTP Parameter Pollution could increase impact of the  XSS flaw by promoting it from a reflected XSS to a stored XSS. (Submitted by Agit Kaplan)
 

--- a/pages/xss-filter-evasion-cheatsheet.md
+++ b/pages/xss-filter-evasion-cheatsheet.md
@@ -851,7 +851,7 @@ Assuming `http://www.google.com/` is programmatically replaced with nothing). I 
 
 ## Assisting XSS with HTTP Parameter Pollution
 
-Assume a content sharing flow on a web site is implemented as below. There is a "Content" page which includes some content provided by users and this page also includes a link to "Share" page which enables a user choose his/her favourite social sharing platform to share on it. Developers HTML attribute encoded "title" parameter in "Content" page to prevent from XSS but for some reasons they didn't URL encoded this parameter to prevent from HTTP Parameter Pollution. And also they thought as content_type's value is a constant and it will always be integer as a result of this they didn't encode or validate content_type in "Share" page.
+Assume a content sharing flow on a web site is implemented as below. There is a "Content" page which includes some content provided by users and this page also includes a link to "Share" page which enables a user choose their favorite social sharing platform to share it on. Developers HTML encoded the "title" parameter in the "Content" page to prevent against XSS but for some reasons they didn't URL encoded this parameter to prevent from HTTP Parameter Pollution. Finally they decide that since content_type's value is a constant and will always be integer, they didn't encode or validate the content_type in the "Share" page.
 
 **Content page source code:**
 


### PR DESCRIPTION
To be able to explain why UrlEncoding is required in Rule#5 XSS preventation cheatsheet (https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html) we might need this example.