### PR TITLE
Fix Debricked Link in Component_Analysis.md

### DIFF
--- a/pages/Component_Analysis.md
+++ b/pages/Component_Analysis.md
@@ -293,7 +293,7 @@ and legal teams an opportunity to create solutions for healthy open source usage
 [CAST Highlight]: https://www.castsoftware.com/SCA/
 [Clarity]: https://www.insignary.com/
 [ClearlyDefined]: https://clearlydefined.io/
-[Debricked] : https://debricked.com/
+[Debricked]: https://debricked.com/
 [DejaCode]: https://www.nexb.com/
 [Dependency-Check]: https://owasp.org/www-project-dependency-check/
 [Dependency-Track]: https://owasp.org/www-project-dependency-track/


### PR DESCRIPTION
Removed extraneous whitespace character from "Debricked" link in `Component_Analysis.md`.  This results in correct display of the link...  and also fixes the next 25 or so links in the table (all of which had been broken by the single extra whitespace!