### PR TITLE
FPD make example link format consistent

### DIFF
--- a/pages/attacks/Full_Path_Disclosure.md
+++ b/pages/attacks/Full_Path_Disclosure.md
@@ -44,8 +44,9 @@ configuration files.
     ?>
 
 An attacker crafts a URL like so:
-\[<http://site.com/index.php?page=>../../../../../../../home/example/public_html/includes/config.php
-<http://site.com/index.php?page=>../../../../../../../home/example/public_html/includes/config.php\]
+
+    http://site.com/index.php?page=../../../../../../../home/example/public_html/includes/config.php
+
 with the knowledge of the FPD in combination with [Relative Path
 Traversal](https://owasp.org/www-community/attacks/Path_Traversal).
 

--- a/pages/attacks/Full_Path_Disclosure.md
+++ b/pages/attacks/Full_Path_Disclosure.md
@@ -44,9 +44,7 @@ configuration files.
     ?>
 
 An attacker crafts a URL like so:
-
-    http://site.com/index.php?page=../../../../../../../home/example/public_html/includes/config.php
-
+`http://site.com/index.php?page=../../../../../../../home/example/public_html/includes/config.php`
 with the knowledge of the FPD in combination with [Relative Path
 Traversal](https://owasp.org/www-community/attacks/Path_Traversal).
 


### PR DESCRIPTION
Currently, the link with the path to config example looks doubled and broken. I changed the format of the link to make it consistent with other examples on the page.