### PR TITLE
Replaced 2x dead references and removed SQLiX ref

### DIFF
--- a/pages/attacks/SQL_Injection.md
+++ b/pages/attacks/SQL_Injection.md
@@ -249,7 +249,7 @@ application secure against SQL injection attacks.
 
 ## Related [Attacks](https://owasp.org/www-community/attacks/)
 
-- [SQL Injection Bypassing  WAF](https://www.owasp.org/index.php/SQL_Injection_Bypassing_WAF)
+- [SQL Injection Bypassing WAF](https://www.owasp.org/index.php/SQL_Injection_Bypassing_WAF)
 - [Blind SQL Injection](Blind_SQL_Injection)
 - [Code Injection](Code_Injection)
 - [Double Encoding](../Double_Encoding)
@@ -257,10 +257,9 @@ application secure against SQL injection attacks.
 
 ## References
 
-- [SQL Injection Knowledge  Base](http://www.websec.ca/kb/sql_injection) - A reference guide for  MySQL, MSSQL and Oracle SQL Injection attacks.
-- [GreenSQL Open Source SQL Injection  Filter](http://www.greensql.net/) - An Open Source database firewall  used to protect databases from SQL injection attacks.
-- [An Introduction to SQL Injection Attacks for Oracle  Developers](https://web.archive.org/web/20151005235207/http://www.net-security.org/dl/articles/IntegrigyIntrotoSQLInjectionAttacks.pdf)
+- [SQL Injection Knowledge Base](http://www.websec.ca/kb/sql_injection) - A reference guide for MySQL, MSSQL and Oracle SQL Injection attacks.
+- [GreenSQL Open Source SQL Injection Filter](http://www.greensql.net/) - An Open Source database firewall used to protect databases from SQL injection attacks.
+- [An Introduction to SQL Injection Attacks for Oracle Developers](https://web.archive.org/web/20151005235207/http://www.net-security.org/dl/articles/IntegrigyIntrotoSQLInjectionAttacks.pdf)
   - This also includes recommended defenses.
-- [Pangolin](https://web.archive.org/web/20130704145839/http://www.nosec.org/en/productservice/pangolin) - Closed source  SQL Injection Scanner.
 
 [Category:Injection](https://owasp.org/www-community/Injection_Flaws)

--- a/pages/attacks/SQL_Injection.md
+++ b/pages/attacks/SQL_Injection.md
@@ -259,9 +259,8 @@ application secure against SQL injection attacks.
 
 - [SQL Injection Knowledge  Base](http://www.websec.ca/kb/sql_injection) - A reference guide for  MySQL, MSSQL and Oracle SQL Injection attacks.
 - [GreenSQL Open Source SQL Injection  Filter](http://www.greensql.net/) - An Open Source database firewall  used to protect databases from SQL injection attacks.
-- [An Introduction to SQL Injection Attacks for Oracle  Developers](http://www.net-security.org/dl/articles/IntegrigyIntrotoSQLInjectionAttacks.pdf)
+- [An Introduction to SQL Injection Attacks for Oracle  Developers](https://web.archive.org/web/20151005235207/http://www.net-security.org/dl/articles/IntegrigyIntrotoSQLInjectionAttacks.pdf)
   - This also includes recommended defenses.
-- OWASP [SQLiX Project](:Category:OWASP_SQLiX_Project "wikilink") - An  SQL Injection Scanner.
-- [Pangolin](http://www.nosec.org/en/pangolin.html) - Closed source  SQL Injection Scanner.
+- [Pangolin](https://web.archive.org/web/20130704145839/http://www.nosec.org/en/productservice/pangolin) - Closed source  SQL Injection Scanner.
 
 [Category:Injection](https://owasp.org/www-community/Injection_Flaws)


### PR DESCRIPTION
As far as I'm aware, OWASP SQLiX is no longer maintained as I wasn't able to find any non-404 pages on the OWASP site for it.
Some references are quite dated (going back to 2004), it may be due for a refresh.

Cheers!