### PR TITLE
Fixing broken URLs

### DIFF
--- a/_data/tools.json
+++ b/_data/tools.json
@@ -963,15 +963,6 @@
       "type": "SAST"
    },
    {
-      "title": "Julia",
-      "url": "https://juliasoft.com/solutions",
-      "owner": "JuliaSoft",
-      "license": "Commercial",
-      "platforms": null,
-      "note": "SaaS Java static analysis",
-      "type": "SAST"
-   },
-   {
       "title": "Klocwork",
       "url": "https://www.perforce.com/products/klocwork",
       "owner": "Perforce",
@@ -1261,7 +1252,7 @@
    },
    {
       "title": "VisualCodeGrepper",
-      "url": "https://www.splint.https://sourceforge.net/projects/visualcodegrepp/",
+      "url": "https://sourceforge.net/projects/visualcodegrepp/",
       "owner": null,
       "license": "Open Source or Free",
       "platforms": "Windows",

--- a/pages/Anti_CRSF_Tokens_ASP.NET.md
+++ b/pages/Anti_CRSF_Tokens_ASP.NET.md
@@ -155,7 +155,7 @@ questions:
 
 # Related [Attacks](https://owasp.org/www-community/attacks/)
 
-[CSRF (Attack)](https://owasp.org/www-community/attacks/csrf/)
+[CSRF (Attack)](https://owasp.org/www-community/attacks/csrf)
 [CSRF (Full Wikipedia Article)](https://en.wikipedia.org/wiki/Cross-site_request_forgery)
 [XSS (Attack)](https://owasp.org/www-community/attacks/xss/)
 

--- a/pages/Fuzzing.md
+++ b/pages/Fuzzing.md
@@ -184,7 +184,7 @@ appear these days; some examples:
 
 <!-- end list -->
 
-  - One may use tools like [Hachoir](http://hachoir.org/) as a generic
+  - One may use tools like [Hachoir](https://hachoir.readthedocs.io/) as a generic
     parser for file format fuzzer development.
 
 ## Fuzzers advantages
@@ -231,7 +231,7 @@ Recent fuzzing initiatives:
 <!-- end list -->
 
   - The [Month of Browser Bugs](http://browserfun.blogspot.com/)
-    ([review here](http://osvdb.org/blog/?p=127)); number of bugs found:
+    ; number of bugs found:
     MSIE: 25 Apple Safari: 2 Mozilla: 2 Opera: 1 Konqueror: 1; used
     DHTML, Css, DOM, ActiveX fuzzing tools
 
@@ -266,8 +266,7 @@ archive](https://web.archive.org/web/20090202043027/http://www.whitestar.linuxbo
 
 #### Mutational Fuzzers
 
-[american fuzzy
-lop](https://en.wikipedia.org/wiki/American_fuzzy_lop_\(fuzzer\))
+[american fuzzy lop](https://en.wikipedia.org/wiki/American_fuzzy_lop_%28fuzzer%29)
 
 [Radamsa - a flock of fuzzers](https://github.com/aoh/radamsa)
 

--- a/pages/OWASP_Application_Security_FAQ.md
+++ b/pages/OWASP_Application_Security_FAQ.md
@@ -75,7 +75,7 @@ We should first ask the user to supply some details like personal
 details or ask a hint question. Then we should send a mail to the users
 authorized mail id with a link which will take the user to a page for
 resetting the password. This link should be active for only a short
-time, and should be SSL- enabled. This way the actual password is never
+time, and should be SSL-enabled. This way the actual password is never
 seen. The security benefits of this method are: the password is not sent
 in the mail; since the link is active for a short time, there is no harm
 even if the mail remains in the mailbox for a long time.
@@ -95,9 +95,10 @@ intervention after a few failed attempts. A method used by a number of
 sites these days is to have the user read and enter a random word that
 appears in an image on the page. Since this cannot be done by a tool, we
 can thwart automated password guessing. The following are some tools
-that guess passwords of web applications: Brutus -
-<http://www.hoobie.net/brutus/> WebCracker
-<http://www.securityfocus.com/tools/706>
+that guess passwords of web applications:
+
+* Brutus
+* [http://www.securityfocus.com/tools/706](WebCracker)
 
 ## How can I protect against keystroke loggers on the client machine?
 
@@ -527,8 +528,8 @@ and compare the responses with the database. This is the technique used
 by tools like Fire & Water. This tool can be found at
 <http://www.ntobjectives.com/products/firewater/> There is a paper by
 Saumil Shah that discusses the tool httprint at
-<http://net-square.com/httprint/httprint_paper.html> httprint can be
-found at <http://net-square.com/httprint/>
+<http://net-square.com/httprint_paper.html> httprint can be
+found at <http://net-square.com/httprint.html>
 
 ## A friend told me it's safer to run my web server on a non-standard port. Is that right?
 
@@ -588,9 +589,10 @@ find](http://www.plynt.com/resources/learn/tools/what_cant_a_scanner_find_1/).
 
 In our tests using a slightly modified WebGoat the best Black-box
 scanning tool found less than 20% of the issues \! Some tools for
-automated scanning are: SpikeProxy, open source and freely available at
-<http://www.immunitysec.com/spikeproxy.html> WebInspect, can be found at
-<http://www.spidynamics.com/productline/WE_over.html>
+automated scanning are:
+
+* [http://manpages.ubuntu.com/manpages/trusty/man1/spikeproxy.1.html](SpikeProxy)
+* [https://www.microfocus.com/en-us/products/webinspect-dynamic-analysis-dast/overview](WebInspect)
 
 ## Where can I try out my testing skills? Is there a sample application I can practice with?
 
@@ -956,10 +958,8 @@ Michael Howard, David LeBlanc and John Viega
 
 Microsoft offers training programs on Developing Security-Enhanced Web
 Applications and Developing and Deploying Secure Microsoft .NET
-Framework Application. More information can be found at
-<http://www.microsoft.com/traincert/syllabi/2300AFinal.asp> and
-<http://www.microsoft.com/traincert/syllabi/2350BFinal.asp> Foundstone
-offers secure coding training through Global Knowledge Aspect Security
-offers a similar course.
+Framework Application. 
+Foundstone offers secure coding training through Global Knowledge Aspect
+Security offers a similar course.
 
 OWASP_FAQ_Ver3.doc

--- a/pages/Security_Headers.md
+++ b/pages/Security_Headers.md
@@ -18,9 +18,9 @@ by default there are secure settings which should be enabled unless
 there are other overriding concerns.
 
   - X-Frame-Options: SAMEORIGIN
-    [1](https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options%7Cref)
+    [1](https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options)
   - X-XSS-Protection: 1; mode=block
-    [2](http://blogs.msdn.com/b/ieinternals/archive/2011/01/31/controlling-the-internet-explorer-xss-filter-with-the-x-xss-protection-http-header.aspx%7Cref)
+    [2](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection)
   - X-Content-Type-Options: nosniff
   - Content-Type: text/html; charset=utf-8
 

--- a/pages/attacks/Blind_SQL_Injection.md
+++ b/pages/attacks/Blind_SQL_Injection.md
@@ -196,12 +196,12 @@ vulnerabilities.
 - Kevin Spett from SPI Dynamics:
   - http://www.net-security.org/dl/articles/Blind_SQLInjection.pdf
   - http://www.imperva.com/resources/whitepapers.asp?t=ADC
-  - [Advanced SQL Injection](https://www.owasp.org/images/7/74/Advanced_SQL_Injection.ppt)
+  - [Advanced SQL Injection](https://wiki.owasp.org/images/7/74/Advanced_SQL_Injection.ppt)
 
 ### Tools
 
 - [SQL Power Injector](http://www.sqlpowerinjector.com/)
-- [Absinthe :: Automated Blind SQL Injection](http://www.0x90.org/releases/absinthe/) // ver1.3.1
+- [Absinthe :: Automated Blind SQL Injection](https://github.com/cameronhotchkies/Absinthe)
 - [SQLBrute - Multi Threaded Blind SQL Injection Bruteforcer](http://www.securiteam.com/tools/5IP0L20I0E.html) in Python
 - [SQLiX - SQL Injection Scanner](:Category:OWASP_SQLiX_Project "wikilink") in Perl
 - [sqlmap, automatic SQL injection tool](http://sqlmap.org/) in Python

--- a/pages/attacks/Buffer_overflow_attack.md
+++ b/pages/attacks/Buffer_overflow_attack.md
@@ -266,4 +266,4 @@ See the [OWASP Code Review Guide](https://owasp.org/www-project-code-review-guid
 
 ## References
 
-- [SmashStack](http://insecure.org/stf/smashstack.html>=)
+- [SmashStack](http://insecure.org/stf/smashstack.html)

--- a/pages/attacks/Credential_stuffing.md
+++ b/pages/attacks/Credential_stuffing.md
@@ -91,7 +91,7 @@ credential stuffing.
     Attackers then used these stolen credentials to try to log in to
     sites across the internet, including Dropbox”.
       - Source: Dropbox.
-        [4](https://blog.dropbox.com/2014/10/dropbox-wasnt-hacked/)
+        [4](https://blog.dropbox.com/topics/company/dropbox-wasnt-hacked/)
 
 <!-- end list -->
 

--- a/pages/attacks/Cross-User_Defacement.md
+++ b/pages/attacks/Cross-User_Defacement.md
@@ -89,7 +89,7 @@ This way it was possible to replace the web page, which was served to
 the specified user.
 
 More information can be found in one of the presentations under
-<http://www.owasp.org/images/1/1a/OWASPAppSecEU2006_HTTPMessageSplittingSmugglingEtc.ppt>
+<http://wiki.owasp.org/images/1/1a/OWASPAppSecEU2006_HTTPMessageSplittingSmugglingEtc.ppt>
 
 ## Related [Threat Agents](Threat_Agents "wikilink")
 

--- a/pages/attacks/Cross_Site_History_Manipulation_(XSHM).md
+++ b/pages/attacks/Cross_Site_History_Manipulation_(XSHM).md
@@ -113,7 +113,7 @@ redirect, then this application is vulnerable to **XSHM** and
 essentially it is a similar to a direct exposure to [Universal
 XSS](media:OWASP_IL_The_Universal_XSS_PDF_Vulnerability.pdf "wikilink")
 – the application itself is
-[XSS](Cross-site_Scripting_\(XSS\) "wikilink")-safe, but running it from
+[XSS](https://owasp.org/www-community/attacks/xss)-safe, but running it from
 a different site inside an IFRAME makes it vulnerable.
 
 ## Related [Threat Agents](Threat_Agents "wikilink")
@@ -123,19 +123,9 @@ TBD
 ## Related [Attacks](https://owasp.org/www-community/attacks/)
 
   - [Cross-site Scripting
-    (XSS)](Cross-site_Scripting_\(XSS\) "wikilink")
+    (XSS)](https://owasp.org/www-community/attacks/xss)
   - [Cross-Site Request Forgery
-    (CSRF)](Cross-Site_Request_Forgery_\(CSRF\) "wikilink")
-
-## Related [Vulnerabilities](https://owasp.org/www-community/vulnerabilities/)
-
-  - [Cross Site Scripting Flaw](Cross_Site_Scripting_Flaw "wikilink")
-
-## Related [Controls](https://owasp.org/www-community/controls/)
-
-  - [Input Validation](Input_Validation "wikilink")
-  - [Output Validation](Output_Validation "wikilink")
-  - [Canonicalization](Canonicalization "wikilink")
+    (CSRF)](https://owasp.org/www-community/attacks/csrf)
 
 ## References
 

--- a/pages/attacks/Cross_Site_Tracing.md
+++ b/pages/attacks/Cross_Site_Tracing.md
@@ -141,8 +141,8 @@ TBD
     <http://www.cgisecurity.com/whitehat-mirror/WH-WhitePaper_XST_ebook.pdf>
   - [Testing for HTTP Methods and XST
     (OWASP-CM-008)](Testing_for_HTTP_Methods_and_XST_\(OWASP-CM-008\) "wikilink")
-  - [OSVDB 877](http://osvdb.org/show/osvdb/877)
-  - [CVE-2005-3398](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2005-3398)
+  - [OSVDB 877](https://vulners.com/osvdb/OSVDB:877)
+  - [CVE-2005-3398](https://nvd.nist.gov/vuln/detail/CVE-2005-3398)
   - [XSS: Gaining access to HttpOnly Cookie
     in 2012](http://seckb.yehg.net/2012/06/xss-gaining-access-to-httponly-cookie.html)
   - [Mozilla

--- a/pages/attacks/DOM_Based_XSS.md
+++ b/pages/attacks/DOM_Based_XSS.md
@@ -131,7 +131,7 @@ Applications from Universal PDF XSS: A discussion of how weird the web
 application security world has become" at the [2007 OWASP Europe AppSec
 Conference](OWASP_AppSec_Europe_2007_-_Italy "wikilink") in Milan. The
 presentation (\[5\]) can be downloaded
-[here](http://www.owasp.org/images/c/c2/OWASPAppSec2007Milan_ProtectingWebAppsfromUniversalPDFXSS.ppt).
+[here](https://wiki.owasp.org/images/c/c2/OWASPAppSec2007Milan_ProtectingWebAppsfromUniversalPDFXSS.ppt).
 
 ### Extensions
 
@@ -202,7 +202,7 @@ Giorgio Fedon, December 2006
 \[5\] "Protecting Web Applications from Universal PDF XSS" (2007 OWASP
 Europe AppSec presentation) Ivan Ristic, May 2007
 
-<http://www.owasp.org/images/c/c2/OWASPAppSec2007Milan_ProtectingWebAppsfromUniversalPDFXSS.ppt>
+<https://wiki.owasp.org/images/c/c2/OWASPAppSec2007Milan_ProtectingWebAppsfromUniversalPDFXSS.ppt>
 
 \[6\] OWASP Testing Guide
 

--- a/pages/attacks/Full_Path_Disclosure.md
+++ b/pages/attacks/Full_Path_Disclosure.md
@@ -44,7 +44,7 @@ configuration files.
     ?>
 
 An attacker crafts a URL like so:
-`http://site.com/index.php?page=../../../../../../../home/example/public_html/includes/config.php`
+`http://example.org/index.php?page=../../../../../../../home/example/public_html/includes/config.php`
 with the knowledge of the FPD in combination with [Relative Path
 Traversal](https://owasp.org/www-community/attacks/Path_Traversal).
 
@@ -88,12 +88,12 @@ launching exploits requiring working usernames.
 
 If we have a site that uses a method of requesting a page like this:
 
-    http://site.com/index.php?page=about
+    http://example.org/index.php?page=about
 
 We can use a method of opening and closing braces that causes the page
 to output an error. This method would look like this:
 
-    http://site.com/index.php?page[]=about
+    http://example.org/index.php?page[]=about
 
 This renders the page defunct thus spitting out an error:
 
@@ -158,7 +158,7 @@ directly requested. Sometimes, it's a clue to Local File Inclusion
 vulnerability.
 
 Concerning with Mambo CMS, if we access to a direct url,
-<http://site.com/mambo/mambots/editors/mostlyce/jscripts/tiny_mce/plugins/spellchecker/classes/PSpellShell.php>,
+<http://example.org/mambo/mambots/editors/mostlyce/jscripts/tiny_mce/plugins/spellchecker/classes/PSpellShell.php>,
 then we gets
 
     <br />

--- a/pages/attacks/Regular_expression_Denial_of_Service_-_ReDoS.md
+++ b/pages/attacks/Regular_expression_Denial_of_Service_-_ReDoS.md
@@ -166,9 +166,9 @@ will hang.
 - [ReDOS Attacks: From the Exploitation to the Prevention (in .NET)](https://dzone.com/articles/regular-expressions-denial)
 - [Tool for detecting ReDoS vulnerabilities.](http://www.cs.bham.ac.uk/~hxt/research/rxxr.shtml)
 - Examples of ReDoS in open source applications:
-    - [ReDoS in DataVault](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2009-3277)
-    - [ReDoS in EntLib](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2009-3275)
-    - [ReDoS in NASD CORE.NET Terelik](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2009-3276)
+    - [ReDoS in DataVault](https://nvd.nist.gov/vuln/detail/CVE-2009-3277)
+    - [ReDoS in EntLib](https://nvd.nist.gov/vuln/detail/CVE-2009-3275)
+    - [ReDoS in NASD CORE.NET Terelik](https://nvd.nist.gov/vuln/detail/CVE-2009-3276)
     - [ReDoS in .NET Framework](http://blog.malerisch.net/2015/09/net-mvc-redos-denial-of-service-vulnerability-cve-2015-2526.html)
     - [ReDoS in Javascript minimatch](https://nodesecurity.io/advisories/118)
 

--- a/pages/attacks/SQL_Injection_Bypassing_WAF.md
+++ b/pages/attacks/SQL_Injection_Bypassing_WAF.md
@@ -120,9 +120,8 @@ can be used (e.g., \#\#\#\#\#, %00).*
 ` /?id=1;select+1&id=2,3+from+users+where+id=1--`
 
 *Successful conduction of an HPP attack bypassing WAF depends on the
-environment of the application being attacked.*
-*\[<http://www>..org/images/b/ba/AppsecEU09_CarettoniDiPaola_v0.8.pdf
-EU09 Luca Carettoni, Stefano diPaola\].*
+environment of the application being attacked.
+*[http://wiki.owasp.org/images/b/ba/AppsecEU09_CarettoniDiPaola_v0.8.pdf](EU09 Luca Carettoni, Stefano diPaola)*
 
 ![<File:Sqli-HPP.png>](Sqli-HPP.png "File:Sqli-HPP.png")
 

--- a/pages/controls/Bytecode_obfuscation.md
+++ b/pages/controls/Bytecode_obfuscation.md
@@ -115,4 +115,4 @@ commands:
 - [Proguard](https://www.guardsquare.com/en/proguard)
 - [Javaguard](http://sourceforge.net/projects/javaguard/)
 - [Elements of Java Obfuscation](https://www.preemptive.com/obfuscation)
-- [Software Obfuscation](https://en.wikipedia.org/wiki/Obfuscation_\(software\))
+- [Software Obfuscation](https://en.wikipedia.org/wiki/Obfuscation_%28software%29)

--- a/pages/initiatives/code_sprint/cs2017.md
+++ b/pages/initiatives/code_sprint/cs2017.md
@@ -204,7 +204,7 @@ Simon Bennetts and the rest of the ZAP Core Team
 
 ### Bamboo Support
 
-ZAP already has an official plugin for Jenkins https://wiki.jenkins-ci.org/display/JENKINS/zap+plugin. 
+ZAP already has an official plugin for Jenkins https://plugins.jenkins.io/zap/. 
 
 It would be great if we also had similar integration for Bamboo https://www.atlassian.com/software/bamboo, https://en.wikipedia.org/wiki/Bamboo_(software)
 

--- a/pages/initiatives/code_sprint/wcs2014.md
+++ b/pages/initiatives/code_sprint/wcs2014.md
@@ -22,7 +22,7 @@ You make excellent contacts and you participate in an international team
 
 Students who successfully(*) participate in the project will get:
 
-* An OWASP annual individual membership. More info [here](http://owasp.com/index.php/Individual_Member)
+* An OWASP annual individual membership. More info [here](https://owasp.org/membership/)
 * An OWASP Winter Code Sprint t-shirt.
 * An OWASP conference pass (no flight/accommodation - just an OWASP conference pass of choice)
 

--- a/pages/initiatives/gsoc/gsoc2013ideas.md
+++ b/pages/initiatives/gsoc/gsoc2013ideas.md
@@ -507,7 +507,7 @@ The automated functionality of OWASP OWTF is currently limited to the non-authen
 2) Configuration files
 
 What we would like to do here is to leverage the [powerful mechanize python library](http://wwwsearch.sourceforge.net/mechanize/) and build at least support for the following authentication options:
-* Basic authentication - As requested here: [Issue 91](https://github.com/7a/owtf/issues/9 https://github.com/7a/owtf/issues/91).
+* Basic authentication - As requested here: [Issue 91](https://github.com/7a/owtf/issues/91).
 * Cookie based authentication
 * Form-based authentication
 
@@ -586,7 +586,7 @@ For background on OWASP OWTF please see: [OWASP_OWTF](https://www.owasp.org/inde
 #### Additional Information and Suggestions (based on student questions):
 
 * Play with the interactive reports to see where we are now (get the OWTF 0.15 one, <b>no need to install anything</b>): [demos](https://github.com/7a/owtf_demos)
-* Reports are created with [report framework](https://github.com/7a/owtf/tree/master/framework/report) and [includes](https://github.com/7a/owtf/tree/master/includes) producing interactive reports such as [demos](https://github.com/7a/owtf_demos https://github.com/7a/owtf_demos)
+* Reports are created with [report framework](https://github.com/7a/owtf/tree/master/framework/report) and [includes](https://github.com/7a/owtf/tree/master/includes) producing interactive reports such as [demos](https://github.com/7a/owtf_demos)
 * How it works at the moment: Each plugin creates its own small report which is loaded by the main report in an iframe, this will make more sense when you play with the interactive demos and look at the source.
 * How the report is meant to be used: I would suggest to watch the live demos in this talk to get the drift of this (Demos start after 1h approx.): [talk](http://www.rubcast.rub.de/index2.php?id=1009)
 * How the report is created now: Each plugin report is created right after each plugin finishes, then the master report is reassembled again: This approach is not very efficient so I am open to alternatives. Not all plugins run tools, some plugins run OWTF checks. But the report will be re-written each time a plugin finishes (using the current approach)

--- a/pages/initiatives/gsoc/gsoc2015ideas.md
+++ b/pages/initiatives/gsoc/gsoc2015ideas.md
@@ -692,7 +692,7 @@ Abraham Aranguren - OWASP OWTF Project Leader - Contact: Abraham.Aranguren@owasp
 
 #### Brief Explanation:
 
-This project is to implement what was suggested in the following [github issue](https://github.com/owtf/owtf/issues/192 https://github.com/owtf/owtf/issues/192)
+This project is to implement what was suggested in the following [github issue](https://github.com/owtf/owtf/issues/192)
 
 Recently i tried to make a fresh installation of OWTF. The installation process takes too much time. Is there any way to make the installation faster?
 Having a private server with:

--- a/pages/initiatives/gsoc/gsoc2017ideas.md
+++ b/pages/initiatives/gsoc/gsoc2017ideas.md
@@ -329,7 +329,7 @@ Simon Bennetts and the rest of the ZAP Core Team
 
 ### Bamboo Support
 
-ZAP already has an official plugin for Jenkins (https://wiki.jenkins-ci.org/display/JENKINS/zap+plugin). 
+ZAP already has an official plugin for Jenkins (https://plugins.jenkins.io/zap/). 
 
 It would be great if we also had similar integration for Bamboo (https://www.atlassian.com/software/bamboo, https://en.wikipedia.org/wiki/Bamboo_(software))
 

--- a/pages/initiatives/gsoc/gsoc2018ideas.md
+++ b/pages/initiatives/gsoc/gsoc2018ideas.md
@@ -157,7 +157,7 @@ Simon Benetts and the rest of the ZAP Core Team
 ###  Develop Bamboo Addon 
 #### Brief Explanation:
 
-It would be great to have an official ZAP add-on for [Bamboo](https://www.atlassian.com/software/bamboo), equivalent to the one we now have for [Jenkins](https://wiki.jenkins.io/display/JENKINS/zap+plugin)
+It would be great to have an official ZAP add-on for [Bamboo](https://www.atlassian.com/software/bamboo), equivalent to the one we now have for [Jenkins](https://plugins.jenkins.io/zap/)
 
 For more information about Bamboo plugins see the [Bamboo plugin guide](https://developer.atlassian.com/server/bamboo/bamboo-plugin-guide/).
 
@@ -398,7 +398,7 @@ Mentors are: Ali Razmjoo Qalaei, Abbas Naderi Afooshteh, SRI HARSHA Gajavalli
 
 [Offensive Web Testing Framework (OWTF)](https://github.com/owtf/owtf) is a project focused on penetration testing efficiency and alignment of security tests to security standards like the OWASP Testing Guide (v3 and v4), 
 the OWASP Top 10, PTES and NIST. Most of the ideas below focus on rewrite of some major components of OWTF to make it more modular. OWTF is moving to a fresh codebase with a fully Docker testing and deployment environment. 
-If you want to get a jumpstart, check out https://github.com/owtf/owtf/tree/new-arch.
+If you want to get a jumpstart, check out https://github.com/owtf/owtf/tree/new.
 
 ### OWASP OWTF - MiTM proxy interception and replay capabilities
 

--- a/pages/initiatives/gsoc/gsoc2019.md
+++ b/pages/initiatives/gsoc/gsoc2019.md
@@ -220,7 +220,7 @@ The PostgreSQL project has also released a list of
 that you can take a look.
 
 The KDE project has also released a guide on how to write a [kickass
-proposal](http://teom.org/blog/kde/how-to-write-a-kick-ass-proposal-for-google-summer-of-code/)
+proposal](https://teom.wordpress.com/2012/03/01/how-to-write-a-kick-ass-proposal-for-google-summer-of-code/)
 
 ## Instructions for mentors
 

--- a/pages/initiatives/gsoc/gsoc2019ideas.md
+++ b/pages/initiatives/gsoc/gsoc2019ideas.md
@@ -337,7 +337,7 @@ if any bugs please help to fix it
 [Offensive Web Testing Framework (OWTF](https://github.com/owtf/owtf) is a project focused on penetration testing efficiency and alignment of security tests 
 to security standards like the OWASP Testing Guide (v3 and v4), the OWASP Top 10, PTES and NIST. Most of the ideas below focus on rewrite of some major 
 components of OWTF to make it more modular. OWTF is moving to a fresh codebase with a fully Docker testing and deployment environment. If you want to get a 
-jumpstart, check out: [new arch](https://github.com/owtf/owtf/tree/new-arch).
+jumpstart, check out: [new arch](https://github.com/owtf/owtf/tree/new).
 
 ### OWASP OWTF - Passive Online scanner improvements
 

--- a/pages/initiatives/gsoc/gsoc2020.md
+++ b/pages/initiatives/gsoc/gsoc2020.md
@@ -213,7 +213,7 @@ The PostgreSQL project has also released a list of
 that you can take a look.
 
 The KDE project has also released a guide on how to write a [kickass
-proposal](http://teom.org/blog/kde/how-to-write-a-kick-ass-proposal-for-google-summer-of-code/)
+proposal](https://teom.wordpress.com/2012/03/01/how-to-write-a-kick-ass-proposal-for-google-summer-of-code/)
 
 ## Instructions for mentors
 

--- a/pages/vulnerabilities/Information_exposure_through_query_strings_in_url.md
+++ b/pages/vulnerabilities/Information_exposure_through_query_strings_in_url.md
@@ -51,7 +51,6 @@ The following figure displays how an internal attacker can potentially exploit t
 
 ## References
 
-- [Testing for Exposed Session Variables (OTG-SESS-004)](https://www.owasp.org/index.php/Testing_for_Exposed_Session_Variables_\(OTG-SESS-004\))
 - [Top 10-2017 A3-Sensitive Data Exposure](https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure)
 - [Top 10 2013-A6-Sensitive Data Exposure](https://www.owasp.org/index.php/Top_10_2013-A6-Sensitive_Data_Exposure)
 - [CWE-598: Information Exposure Through Query Strings in GET Request](https://cwe.mitre.org/data/definitions/598.html)

--- a/pages/vulnerabilities/Unrestricted_File_Upload.md
+++ b/pages/vulnerabilities/Unrestricted_File_Upload.md
@@ -486,10 +486,6 @@ And some special recommendations for the developers and webmasters:
     [6](http://www.net-security.org/dl/articles/php-file-upload.pdf)
   - Potentially Dangerous File Types
     [7](http://www.windowsitpro.com/Files/18/27072/Webtable_01.pdf)
-  - Image Upload XSS
-    [8](http://ha.ckers.org/blog/20070603/image-upload-xss/)
-  - Code Execution Through Filenames in Uploads
-    [9](http://ha.ckers.org/blog/20070620/code-execution-through-filenames-in-uploads/)
   - Secure File Upload Check List With PHP
     [10](http://hungred.com/useful-information/secure-file-upload-check-list-php/)
   - NTFS in WikiPedia [11](http://en.wikipedia.org/wiki/NTFS)


### PR DESCRIPTION
Was going through pages, found plenty of broken references. Ran a [broken URL checker](https://www.deadlinkchecker.com/website-dead-link-checker.asp) against the website, found a lot of broken URLs. Fixed some of them, esp. where syntax was concerned, in addition to that, fixed or removed some broken internal references. Also, replaced `site.com` references (real site) with `example.org`. Some URLs remain broken:

```
https://support.google.com/mail/forum/AAAAK7un8RU3J3r2JqFNTw/discussion/?hl=en&gpf=d/topic/gmail/3J3r2JqFNTw/discussion
https://www.javaworld.com/javaworld/javaqa/2003-05/01-qa-0509-jcrypt.html?page=2
http://www.php-security.org/downloads/rips.pdf
http://www.seclab.tuwien.ac.at/papers/pixy.pdf
http://w2spconf.com/2010/papers/p27.pdf
https://www.codemagi.com/blog/post/194
https://www.itu.int/rec/T-REC-X.690-200811-I/en
https://www.ietf.org/id/draft-ietf-websec-key-pinning-09.txt
https://github.com/andresriancho/w3af/blob/master/plugins/grep/csp.py
http://blog.php-security.org/archives/76-Holes-in-most-preg_match-filters.html
http://www.webapptest.org/ms-access-sql-injection-cheat-sheet-EN.html
http://labs.idefense.com/intelligence/vulnerabilities/display.php?id=77
http://www.ruxcon.org.au/files/2008/Attacking_Rich_Internet_Applications.pdf
http://yehg.net/lab/pr0js/files.php/inspath.zip
http://yehg.net/lab/pr0js/files.php/php_brute_force_detect.zip
http://www.comptechdoc.org/independent/web/cgi/ssimanual/ssiexamples.html
http://www.iss.net/security_center/advice/Exploits/TCP/session_hijacking/default.htm
http://www.derkeiler.com/pdf/Mailing-Lists/Securiteam/2002-12/0099.pdf
http://archives.neohapsis.com/archives/bugtraq/2002-05/0118.html
http://hacker-eliminator.com/trojansymptoms.html
http://www.microsoft.com/technet/security/bulletin/MS00-078.mspx
https://www.checkmarx.com/Demo/XSHM.aspx
https://blog.watchfire.com/wfblog/2008/06/javascript-code.html
http://shlang.com/netkill/netkill.html
https://cirt.net/code/nikto.shtml
https://addons.mozilla.org/en-US/firefox/addon/heartbleed-checker/
https://www.ecrimelabs.com/tools/webroot/WebRoot.txt
https://www.cs.rice.edu/~scrosby/hash/slides/USENIX-RegexpWIP.2.ppt
https://www.checkmarx.com/NewsDetails.aspx?id=23&cat=3
https://owasp.org/index.php/Dhiraj_Mishra
http://puzzlemall.googlecode.com/files/Session
https://owasp.org/index.php/Image:RequestRodeo-MartinJohns.pdf
http://windows.stanford.edu/docs/IISsecchecklist.htm
http://www.net-security.org/dl/articles/php-file-upload.pdf
http://www.windowsitpro.com/Files/18/27072/Webtable_01.pdf
https://www.imperva.com/404?aspxerrorpath=/application_defense_center/glossary/forceful_browsing.html
http://info.sen.ca.gov/pub/01-02/bill/sen/sb_1351-1400/sb_1386_bill_20020926_chaptered.html
https://blog.shapesecurity.com/heartbleed-bug-places-encrypted-user-data-and-webservers-at-risk
https://www.mitre.org/sites/default/files/publications/pr-18-2417-deliver-uncompromised-MITRE-study-8AUG2018.pdf
http://www.microsoft.com/technet/security/bulletin/ms04-028.mspx
http://www.digitaldwarf.be/products/mangle.c
http://projects.info-pull.com/mokb/
http://www.bonsai-sec.com/en/research/untidy-xml-fuzzer.php
https://support.snyk.io/snyk-cli/how-can-i-set-a-snyk-cli-project-as-open-source
http://www.rubcast.rub.de/index2.php?id=1009
http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf
http://aeditor.rubyforge.org/ruby_cplusplus/index.html
https://owasp-skf.gitbook.io/asvs-write-ups/filename-injection
http://tomcat.apache.org/tomcat-6.0-doc/config/context.html
https://blog.48bits.com/2010/09/28/iis6-asp-file-upload-for-fun-and-profit/
http://palisade.plynt.com/issues/2006Jun/injection-stored-procedures/
http://www.bindshell.net/tools/odysseus
http://www.ntobjectives.com/products/firewater/
http://home.intekom.com/rdawes/exodus.html
http://www.wastelands.gen.nz/odysseus/index.php
http://www.webcohort.com/web_application_security/research/tools.html
http://www.rsasecurity.com/standards/ssl/basics.html
http://palisade.plynt.com/issues/2005Aug/page-tokens/
http://www.microsoft.com/mspress/books/toc/5612.asp
http://www.seczone.cn/2018/06/27/codesec源代码安全检测平台/
```

If anyone wants to go through these, `grep --color=always -nr -Ff broken_urls_left.txt|grep --color=always -v "broken_"|sort` will show where those URLs are specifically. Could probably also find  a lot of broken internal references by looking for "wikilink".

Please review before merge.