### PR TITLE
Typo fix

### DIFF
--- a/pages/controls/SecureFlag.md
+++ b/pages/controls/SecureFlag.md
@@ -15,7 +15,7 @@ permalink: /controls/SecureFlag
 The secure flag is an option that can be set by the application server
 when sending a new cookie to the user within an HTTP Response. The
 purpose of the secure flag is to prevent cookies from being observed by
-unauthorized parties due to the transmission of a the cookie in clear
+unauthorized parties due to the transmission of the cookie in clear
 text.
 To accomplish this goal, browsers which support the secure flag will
 only send cookies with the secure flag when the request is going to a


### PR DESCRIPTION
Changed "a the cookie" to "the cookie".

<img width="891" alt="Screen Shot 2020-10-23 at 14 38 13" src="https://user-images.githubusercontent.com/45270554/96999404-c5c2d300-153d-11eb-9ffa-a80a90bbd002.png">
