### PR TITLE
Update _data/tools.json for RIPS

### DIFF
--- a/_data/tools.json
+++ b/_data/tools.json
@@ -747,15 +747,6 @@
       "type": "SAST"
    },
    {
-      "title": "RIPS",
-      "url": "http://rips-scanner.sourceforge.net/",
-      "owner": null,
-      "license": "Open Source or Free",
-      "platforms": null,
-      "note": "A static source code analyzer for vulnerabilities in PHP web applications.",
-      "type": "SAST"
-   },
-   {
       "title": "Security Code Scan",
       "url": "https://security-code-scan.github.io/",
       "owner": null,

--- a/_data/tools.json
+++ b/_data/tools.json
@@ -1269,15 +1269,6 @@
       "type": "SAST"
    },
    {
-      "title": "RIPS",
-      "url": "https://www.ripstech.com/product/",
-      "owner": null,
-      "license": "Open Source or Free",
-      "platforms": null,
-      "note": "Java, PHP",
-      "type": "SAST"
-   },
-   {
       "title": "Fortify",
       "url": "https://www.microfocus.com/en-us/products/static-code-analysis-sast/overview",
       "owner": null,


### PR DESCRIPTION
It seems the RIPS project was included three times in the tools.json file. One entry had the tool incorrectly listed as "open source", another entry linked to a old website of the tool. Removed those two entries, and keep the last one that seems to contain all the correct information.