### PR TITLE
Path Traversal: Itemize encoding examples

### DIFF
--- a/pages/attacks/Path_Traversal.md
+++ b/pages/attacks/Path_Traversal.md
@@ -59,14 +59,15 @@ See the [OWASP Testing Guide](https://owasp.org/www-project-web-security-testing
 
 Encoding and double encoding:
 
-`%2e%2e%2f` represents `../`
-`%2e%2e/` represents `../`
-`..%2f` represents `../ `
-`%2e%2e%5c` represents `..\`
-`%2e%2e\` represents `..\ `
-`..%5c` represents `..\ `
-`%252e%252e%255c` represents `..\ `
-`..%255c` represents `..\` 
+- `%2e%2e%2f` represents `../`
+- `%2e%2e/` represents `../`
+- `..%2f` represents `../ `
+- `%2e%2e%5c` represents `..\`
+- `%2e%2e\` represents `..\ `
+- `..%5c` represents `..\ `
+- `%252e%252e%255c` represents `..\ `
+- `..%255c` represents `..\` 
+
 and so on.
 
 #### Percent encoding (aka URL encoding)
@@ -74,8 +75,8 @@ and so on.
 Note that web containers perform one level of decoding on percent
 encoded values from forms and URLs.
 
-`..%c0%af` represents `../ `
-`..%c1%9c` represents `..\ `
+- `..%c0%af` represents `../ `
+- `..%c1%9c` represents `..\ `
 
 #### OS specific
 


### PR DESCRIPTION
makes it easier to read on [webpage](https://owasp.org/www-community/attacks/Path_Traversal).

Before this change it renders as:

![image](https://user-images.githubusercontent.com/1054041/100997552-ac5c7000-355a-11eb-913e-8fde4e7bc7dd.png)
