### PR TITLE
Flag -> Attribute

### DIFF
--- a/pages/controls/SecureAttribute.md
+++ b/pages/controls/SecureAttribute.md
@@ -1,6 +1,6 @@
 ---
 
-title: Secure Cookie Flag
+title: Secure Cookie Attribute
 layout: col-sidebar
 author: MichaelCoates
 contributors: Andrew Smith, Gladwin, Bell Sempf, Wichers, James Jardine, Zerosum0x0, Paco, Dan Wallis, Nawwar, kingthorin
@@ -12,28 +12,28 @@ permalink: /controls/SecureFlag
 
 # Overview
 
-The secure flag is an option that can be set by the application server
+The secure attribute is an option that can be set by the application server
 when sending a new cookie to the user within an HTTP Response. The
-purpose of the secure flag is to prevent cookies from being observed by
+purpose of the secure attribute is to prevent cookies from being observed by
 unauthorized parties due to the transmission of the cookie in clear
 text.
-To accomplish this goal, browsers which support the secure flag will
-only send cookies with the secure flag when the request is going to a
+To accomplish this goal, browsers which support the secure attribute will
+only send cookies with the secure attribute when the request is going to a
 HTTPS page. Said in another way, the browser will not send a cookie with
-the secure flag set over an unencrypted HTTP request.
-By setting the secure flag, the browser will prevent the transmission of
+the secure attribute set over an unencrypted HTTP request.
+By setting the secure attribute, the browser will prevent the transmission of
 a cookie over an unencrypted channel.
 
-# Setting the Secure Flag
+# Setting the Secure Attribute
 
-Following sections describes setting the Secure Flag in respective
+Following sections describes setting the Secure Attribute in respective
 technologies.
 
 ## Java
 
 ### Servlet 3.0 (Java EE 6)
 
-Sun Java EE supports secure flag in Cookie interface since version 6
+Sun Java EE supports secure attribute in Cookie interface since version 6
 (Servlet class version
 3)[1](http://java.sun.com/javaee/6/docs/api/javax/servlet/http/Cookie.html#setSecure%28boolean%29),
 also for session cookies
@@ -71,13 +71,13 @@ can be configured to use a different session identifier than `JSESSIONID`.
 
 ### Environment consideration
 
-With this flag always set, sessions won't work in
+With this attribute always set, sessions won't work in
 environments(development/test/etc.) that may use http.
 SessionCookieConfig
 [3](http://java.sun.com/javaee/6/docs/api/javax/servlet/SessionCookieConfig.html#setSecure%28boolean%29)
 interface or setting custom
 header[4](https://www.owasp.org/index.php/SecureFlag#Setting_it_as_a_custom_header)
-trick can be leveraged to configure setting of this flag differently for
+trick can be leveraged to configure setting of this attribute differently for
 each environment and can be driven by application configuration.
 
 ## ASP.NET
@@ -85,7 +85,7 @@ each environment and can be driven by application configuration.
 Set the following in Web.config: `<httpCookies requireSSL="true" />`
 
 For some objects that have a requireSSL property, like the forms
-Authentication Cookie, set the `requireSSL="true"` flag in the web.config
+Authentication Cookie, set the `requireSSL="true"` attribute in the web.config
 for that specific element. For example: 
 
 ```xml
@@ -97,7 +97,7 @@ for that specific element. For example:
 <code></authentication></code>  
 ```
 
-Which will enable the secure flag on the Forms Authentication cookie, as well as checking that the http request is coming to the server over SSL/TLS connection. Note that in case TLS is offloaded to a load balancer, the requireSSL solution wouldn't work.
+Which will enable the secure attribute on the Forms Authentication cookie, as well as checking that the http request is coming to the server over SSL/TLS connection. Note that in case TLS is offloaded to a load balancer, the requireSSL solution wouldn't work.
  
 Alternatively, the cookies can be set to secure programmatically using the following code by adding a EndRequest event handler to the `Global.asax.cs` file:
 
@@ -112,7 +112,7 @@ protected void Application_EndRequest(Object sender, EventArgs e) {
 
 ## PHP
 
-For session cookies managed by PHP, the flag is set either permanently
+For session cookies managed by PHP, the attribute is set either permanently
 in php.ini [PHP manual on
 *SecureFlag*](http://php.net/manual/en/session.configuration.php#ini.session.cookie-secure)
 through the parameter:
@@ -127,7 +127,7 @@ void session_set_cookie_params ( int $lifetime  [, string $path  [, s
                                   [, bool $secure= false  [, bool $httponly= false  ]]]] )
 ```
 
-For application cookies a parameter in setcookie() sets Secure flag
+For application cookies a parameter in setcookie() sets the secure attribute
 [6](http://pl.php.net/setcookie):
 
 ```
@@ -135,12 +135,12 @@ bool setcookie ( string $name  [, string $value  [, int $expire= 0�
                  [, string $domain  [, bool $secure= false  [, bool $httponly= false  ]]]]]] )
 ```
 
-# Testing for the Secure Flag
+# Testing for the Secure Attribute
 
-Verifying that a web site sets this flag on any particular cookie is
+Verifying that a web site sets this attribute on any particular cookie is
 easy. Using an intercepting proxy, like [ZAP](https://www.zaproxy.org), you can
 capture each response from the server and examine any Set-Cookie headers
-it includes to see if the secure flag is set on the cookie.
+it includes to see if the secure attribute is set on the cookie.
 
 # Related Articles
 

--- a/pages/controls/SecureAttribute.md
+++ b/pages/controls/SecureAttribute.md
@@ -3,7 +3,7 @@
 title: Secure Cookie Attribute
 layout: col-sidebar
 author: MichaelCoates
-contributors: Andrew Smith, Gladwin, Bell Sempf, Wichers, James Jardine, Zerosum0x0, Paco, Dan Wallis, Nawwar, kingthorin
+contributors: Andrew Smith, Gladwin, Bell Sempf, Wichers, James Jardine, Zerosum0x0, Paco, Dan Wallis, Nawwar, kingthorin, Grant Ongers
 permalink: /controls/SecureFlag
 
 ---


### PR DESCRIPTION
I have suggested changing all instances of the word "flag" with the word "attribute" through out this document for a number of reasons:
1.) in order to align this document internally - there were several instances of each term used internally;
2.) to align it with the terminology used in the standard (https://tools.ietf.org/html/rfc6265#section-5.2.5); and 
3.) to align it with the developer guidance from Mozilla (https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies) 

This document came to my attention during a presentation I did on the "OWASP SecureFlag Open Platform" - there was some confusion about the use of the word "flag" as it's used in the context of "Capture the Flag" for the SecureFlag project and the standards talk about a "Secure Attribute" (although they do also talk about setting "boolean flags" in the meaning of "switches").