### PR TITLE
Add Enlightn to SAST list

### DIFF
--- a/_data/tools.json
+++ b/_data/tools.json
@@ -624,7 +624,7 @@
       "title": "Enlightn",
       "url": "https://www.laravel-enlightn.com/",
       "owner": "Enlightn Software",
-      "license": "Commercial and Open Source",
+      "license": "Open Source",
       "platforms": null,
       "note": "Enlightn is a vulnerability scanner specifically designed for Laravel PHP applications that combines SAST, DAST, IAST and configuration analysis techniques to detect vulnerabilities.",
       "type": "SAST"

--- a/_data/tools.json
+++ b/_data/tools.json
@@ -621,6 +621,15 @@
       "type": "SAST"
    },
    {
+      "title": "Enlightn",
+      "url": "https://www.laravel-enlightn.com/",
+      "owner": "Enlightn Software",
+      "license": "Commercial and Open Source",
+      "platforms": null,
+      "note": "Enlightn is a vulnerability scanner specifically designed for Laravel PHP applications that combines SAST, DAST, IAST and configuration analysis techniques to detect vulnerabilities.",
+      "type": "SAST"
+   },
+   {
       "title": "FindBugs",
       "url": "https://github.com/findbugsproject/findbugs",
       "owner": null,


### PR DESCRIPTION
We've developed [Enlightn](https://www.laravel-enlightn.com/), a tool that scans Laravel PHP applications for security vulnerabilities. It has both open source and commercial (Enlightn Pro) versions. Github repo [here](https://github.com/enlightn/enlightn).

[EDIT] I've marked the license as open source as there was no option for both commercial and open source. I think this should be fine as our commercial version is named as "Enlightn Pro".