### PR TITLE
Add more up to date examples for .NET

### DIFF
--- a/pages/controls/Certificate_and_Public_Key_Pinning.md
+++ b/pages/controls/Certificate_and_Public_Key_Pinning.md
@@ -499,7 +499,7 @@ private static bool PinPublicKey(
 	X509Certificate2 certificate,
 	X509Chain chain,
 	SslPolicyErrors sslPolicyErrors)
-{~~~~
+{
 	if (certificate == null)
 		return false;
 


### PR DESCRIPTION
This PR adds more up to date examples of performing certificate pinning in .NET. Using `ServicePointManager.ServerCertificateValidationCallback` affects all requests from the AppDomain, so care must be taken to handle server validation for requests to domains other than the one to which we want to apply certificate pinning. In more recent versions of .NET Framework, server certificate validation can be performed per request, offering better control over `ServicePointManager` on when to apply validation logic.

Usage of `WebRequest` and `HttpWebRequest` have long been superseded by `HttpClient`, which exposes the ability to specify a server certificate validation callback on the `HttpClientHandler` used by the client. This commit adds an example.