### PR TITLE
GSoC 2021

### DIFF
--- a/pages/initiatives/gsoc/gsoc2021.md
+++ b/pages/initiatives/gsoc/gsoc2021.md
@@ -8,304 +8,192 @@ permalink: /initiatives/gsoc/gsoc2021
 # OWASP is applying to be a Google Summer of Code (“GSoC”) mentoring organization in 2021!
 
 Open source software is changing the world and creating the future.
-
-Want to help shape it? We’re looking for students to join us in making
-2021 the best Summer of Code yet!
+Want to help shape it? We’re looking for students to join us in making 2021 the best Summer of Code yet!
 
 ## Schedule
 
-Stay tuned to this space for important upcoming dates and deadlines
-
+Stay tuned to this space for important upcoming dates and deadlines:
 [**Google Summer of Code Program Site**](https://summerofcode.withgoogle.com/)
 
-- OWASP is an open community dedicated to enabling organizations to
-  conceive, develop, acquire, operate, and maintain applications that
-  can be trusted.
-- All students currently enrolled in an accredited institution are
-  welcome to participate in the Google Summer of Code program, hopefully
-  along with the OWASP Foundation.
+- OWASP is an open community dedicated to enabling organizations to conceive, develop, acquire, operate, and maintain applications that can be trusted.
+- All students currently enrolled in an accredited institution are welcome to participate in the Google Summer of Code program, hopefully along with the OWASP Foundation.
 - Below you could find all the instructions on how to participate.
 
 ## What is GSOC?
 
-The
-[Google Summer of Code
-program](https://developers.google.com/open-source/gsoc/) (“GSoC”) is
-designed to encourage student participation in open source development.
-Through GSoC, accepted student applicants will be paired with OWASP
-mentors that will guide them through their coding tasks.
+The [Google Summer of Code program](https://summerofcode.withgoogle.com/) (“GSoC”) is designed to encourage student participation in open source development. Through GSoC, accepted student applicants will be paired with OWASP mentors that will guide them through their coding tasks.
 
 Benefits to students include:
-
 - Gaining exposure to real-world software development scenarios
-- An opportunity for employment in areas related to their academic
-  pursuits and
-- Google will be offering successful student contributors a 5,500 USD
-  stipend, enabling them to focus on their coding projects for three
-  months.
+- An opportunity for employment in areas related to their academic pursuits and
+- Google will be offering successful student contributors a stipend, enabling them to focus on their coding projects for the duration of GSoC.
 
-This program is done completely online. Students and mentors from more
-than 100 countries have participated in past years.
+This program is done completely online. Students and mentors from more than 100 countries have participated in past years.
 
-## Instructions common to all participants
+## Instructions for All Participants
 
-All participants should take a look at the
-[Google Summer of Code
-Program Site](https://developers.google.com/open-source/gsoc/faq) every
-now and then to be informed about updates and advice. It is also
-important to read the
-[Summer of Code
-FAQ](https://developers.google.com/open-source/gsoc/faq), as it contains
-useful information. All participants will need a Google account in order
-to join the program. You'll save some time if you create one now. Please
-review the
-[GSOC TimeLine](https://developers.google.com/open-source/gsoc/timeline)
+All participants should take a look at the [Google Summer of Code Program Site](https://summerofcode.withgoogle.com/) every
+now and then to be informed about updates and advice. It is also important to read the 
+[Summer of Code FAQ](https://developers.google.com/open-source/gsoc/faq), as it contains useful information. All participants will need a Google account in order to join the program. You'll save some time if you create one now. Please
+review the [GSOC TimeLine](https://summerofcode.withgoogle.com/how-it-works/#timeline).
 
 ### Programming Language
 
-Many OWASP tools are developed using Python/Java, but there are also
-some in JavaScript, C++, Ruby, PHP and C#. Submissions and ideas for
-projects should preferably stick to the language(s) used by that
-project. Submissions in any other language should specifically explain
+Many OWASP tools are developed using Python/Java, but there are also some in JavaScript, C++, Ruby, PHP and C#. Submissions and ideas for
+projects should preferably stick to the language(s) used by that project. Submissions in any other language should specifically explain
 their choice.
 
-## Instructions for students
+## Instructions for Students
 
 Are you a student and want to code for an OWASP project? Here are the
 steps and some tips on getting started:
 
-1. Think of a good idea – For reference from last year see
-   [GSoc 2020 Ideas](gsoc2020ideas).
-2. Do some research yourself based on the idea, write up a proposal
-   draft
-3. Post it to the mailing list at
-   [https://groups.google.com/d/forum/owasp-gsoc](https://groups.google.com/forum/#!forum/owasp-gsoc)
-   for initial discussions with OWASP mentors.
-4. Based on feedback, write a full proposal – See template below:
-   [GSoC SAT](gsoc_sat)
+1. Think of a good idea – For reference from last year see [GSoc 2021 Ideas](gsoc2021ideas).
+2. Do some research yourself based on the idea, write up a proposal draft
+3. Post it to the mailing list at [https://groups.google.com/d/forum/owasp-gsoc](https://groups.google.com/forum/#!forum/owasp-gsoc) for initial discussions with OWASP mentors.
+4. Based on feedback, write a full proposal – See template below: [GSoC SAT](gsoc_sat)
 5. Submit your proposal to Google
 
-Students wishing to participate in GSoC must realize this is a formal
-commitment to produce code for the selected OWASP Project during a
-relatively short period of three months. You will also take some
-resources from OWASP project leaders, who will dedicate a portion of
-their time to mentor you. Therefore, we seek candidates who are
-committed to helping OWASP mission and are willing to both provide
-quality results and be engaging with their mentors and community. You
-don't have to be a proven developer -- in fact, this whole program is
-meant to facilitate joining OWASP and other Open Source communities.
-However, experience in coding and applications are welcome.
+Students wishing to participate in GSoC must realize this is a formal commitment to produce code for the selected OWASP Project during a
+relatively short period. You will also take some resources from OWASP project leaders, who will dedicate a portion of
+their time to mentor you. Therefore, we seek candidates who are committed to helping OWASP mission and are willing to both provide
+quality results and be engaging with their mentors and community. You don't have to be a proven developer -- in fact, this whole program is
+meant to facilitate joining OWASP and other Open Source communities. However, experience in coding and applications are welcome.
 
-You should start familiarizing yourself with the projects that you plan
-on working on before the start date. OWASP Project Mentors are available
-on the mailing list
-[https://groups.google.com/d/forum/owasp-gsoc](https://groups.google.com/d/forum/owasp-gsoc)
-for help.
+You should start familiarizing yourself with the projects that you plan on working on before the start date. OWASP Project Mentors are available
+on the mailing list [https://groups.google.com/d/forum/owasp-gsoc](https://groups.google.com/d/forum/owasp-gsoc) for help.
 
-### General instructions
+### General Instructions
 
 First of all, please read the instructions common to all participants
 and the
-[GSoC FAQ](https://developers.google.com/open-source/gsoc/faq). Pay
-special attention to the **Eligibility** section of the FAQ.
+[GSoC FAQ](https://developers.google.com/open-source/gsoc/faq). Pay special attention to the **Eligibility** section of the FAQ.
 
 ### Getting in touch
 
-- Google Group: OWASP Organization Administrators and Mentors are
-  available at
-  [https://groups.google.com/d/forum/owasp-gsoc](https://groups.google.com/d/forum/owasp-gsoc)
-  ready to answer any questions and discuss any idea.
+- Google Group: OWASP Organization Administrators and Mentors are available at [https://groups.google.com/d/forum/owasp-gsoc](https://groups.google.com/d/forum/owasp-gsoc) ready to answer any questions and discuss any idea.
 
-### Recommended steps
+### Recommended Steps
 
-- Read
-  [Google's instructions for
-    participating](https://developers.google.com/open-source/gsoc/) and
-  the
-  [Student
-    Manual](https://developers.google.com/open-source/gsoc/resources/manual#student_manual)
-- Take a look at the list of
-  [GSoC 2021 ideas](gsoc2021ideas)
+- Read [Google's instructions for participating](https://summerofcode.withgoogle.com/get-started/) and the [Student Manual](https://google.github.io/gsocguides/student/about-this-manual)
+- Take a look at the list of [GSoC 2021 ideas](gsoc2021ideas)
 - Come up with project that you're interested in
-- Write a first draft
-  [proposal](gsoc_sat) and get someone to review it for you
+- Write a first draft [proposal](gsoc_sat) and get someone to review it for you
 - Remember: you must link to work such as commits in your proposal
 - Submit it using Google's web interface ahead of the deadline
 - Submit proof of enrollment well ahead of the deadline
 
-Coming up with an interesting idea is probably the most difficult part
-of all. It should be something interesting for an OWASP Project, and
-more importantly for you. It also has to be something that you can
-realistically achieve in the time available to you.
+Coming up with an interesting idea is probably the most difficult part of all. It should be something interesting for an OWASP Project, and
+more importantly for you. It also has to be something that you can realistically achieve in the time available to you.
 
-Finding out what the most pressing issues are in the projects you're
-interested in is a good start. You can optionally join the mailing lists
-for that project: you can make acquaintance with developers and your
-potential mentor, as well as start learning the codebase. We recommend
-strongly doing that and we will look favorably on applications from
-students who have started to act like Open Source developers.
+Finding out what the most pressing issues are in the projects you're interested in is a good start. You can optionally join the mailing lists
+for that project: you can make acquaintance with developers and your potential mentor, as well as start learning the codebase. We recommend
+strongly doing that and we will look favorably on applications from students who have started to act like Open Source developers.
 
-### Student proposal guidelines
+### Student Proposal Guidelines
 
-A project proposal is what you will be judged upon. So, as a general
-recommendation, write a clear proposal on what you plan to do, what your
-project is and what it is not, etc. Several websites now contain hints
-and other useful information on writing up such proposals. OWASP does
-not require a specific format or specific list of information, but there
-is an application template on the OWASP page in Google Melange with some
-specific points that you should address in your application:
+A project proposal is what you will be judged upon. So, as a general recommendation, write a clear proposal on what you plan to do, what your
+project is and what it is not, etc. Several websites now contain hints and other useful information on writing up such proposals. OWASP does
+not require a specific format or specific list of information, but here are some specific points that you should address in your application:
 
 - Who are you? What are you studying?
 - What exactly do you intend to do? What will not be done?
 - Why are you the right person for this task?
-- To what extent are you familiar with the software you're proposing to
-  work with? Have you used it? Have you read the source? Have you
-  modified the source?
+- To what extent are you familiar with the software you're proposing to work with? Have you used it? Have you read the source? Have you modified the source?
 - How many hours are you going to work on this a week? 10? 20? 30? 40?
-- Do you have other commitments that we should know about? If so, please
-  suggest a way to compensate if it will take much time away from Summer
-  of Code.
-- Are you comfortable working independently under a supervisor or mentor
-  who is several thousand miles away, not to mention 12 time zones away?
-  How will you work with your mentor to track your work? Have you worked
-  in this style before?
-- If your native language is not English, are you comfortable working
-  closely with a supervisor whose native language is English? What is
-  your native language, as that may help us find a mentor who has the
-  same native language?
-- Where do you live, and can we assign a mentor who is local to you so
-  you can meet in a coffee shop for lunch?
+- Do you have other commitments that we should know about? If so, please suggest a way to compensate if it will take much time away from Summer of Code.
+- Are you comfortable working independently under a supervisor or mentor who is several thousand miles away, not to mention 12 time zones away? How will you work with your mentor to track your work? Have you worked in this style before?
+- If your native language is not English, are you comfortable working closely with a supervisor whose native language is English? What is your native language, as that may help us find a mentor who has the same native language?
+- Where do you live, and can we assign a mentor who is local to you so you can meet in a coffee shop for lunch?
 
-After you have written your proposal, you should get it reviewed. Do not
-rely on the OWASP mentors to do it for you via the web interface: they
-will only send back a proposal if they find it lacking. Instead, ask a
-colleague or a developer to do it for you.
+After you have written your proposal, you should get it reviewed. Do not rely on the OWASP mentors to do it for you via the web interface: they
+will only send back a proposal if they find it lacking. Instead, ask a colleague or a developer to do it for you.
 
 ### Hints
 
-#### Submit your proposal early:
+#### Submit your proposal early
 
-Early submissions get more attention from developers for the simple fact
-that they have more time to dedicate to reading them. The more people
+Early submissions get more attention from developers for the simple fact that they have more time to dedicate to reading them. The more people
 see it, the more it'll get known.
 
-#### Do not leave it all to the last minute:
+#### Do not leave it all to the last minute
 
-While it is Google that is operating the webserver, it would be wise to
-expect a last-minute overload on the server. So, make sure you send your
-application before the final rush. Also, note that the applications
-submitted very late will get the least attention from mentors, so you
+While it is Google that is operating the webserver, it would be wise to expect a last-minute overload on the server. So, make sure you send your
+application before the final rush. Also, note that the applications submitted very late will get the least attention from mentors, so you
 may get a low vote because of that.
 
-#### Keep it simple:
+#### Keep it simple
 
-We don't need a 10-page essay on the project and on you (Google won't
-even let you submit a text that long). You just need to be concise and
+We don't need a 10-page essay on the project and on you (Google won't even let you submit a text that long). You just need to be concise and
 precise.
 
-#### Know what you are talking about:
+#### Know what you are talking about
 
-The last thing we need is for students to submit ideas that cannot be
-accomplished realistically or ideas that aren't even remotely related to
-OWASP Projects. If your idea is unusual, be sure to explain why you have
-chosen OWASP to be your mentoring organisation.
+The last thing we need is for students to submit ideas that cannot be accomplished realistically or ideas that aren't even remotely related to
+OWASP Projects. If your idea is unusual, be sure to explain why you have chosen OWASP to be your mentoring organisation.
 
-#### Aim wide:
+#### Aim wide
 
-Submit more than one proposal, to different OWASP Projects. We also
-recommend submitting to more than one organisation too. This will
-increase your chances of being chosen. However, it is highly recommended
-not to overdo it. The more applications you do the less time you will
+Submit more than one proposal, to different OWASP Projects. We also recommend submitting to more than one organisation too. This will
+increase your chances of being chosen. However, it is highly recommended not to overdo it. The more applications you do the less time you will
 have to work on each.
 
-The PostgreSQL project has also released a list of
-[hints](http://www.postgresql.org/developer/summerofcodeadvice.html)
-that you can take a look.
+The PostgreSQL project has also released a list of [hints](https://wiki.postgresql.org/wiki/GSoC) that you can take a look at.
 
 The KDE project has also released a guide on how to write a
-[kickass
-proposal](https://teom.wordpress.com/2012/03/01/how-to-write-a-kick-ass-proposal-for-google-summer-of-code/)
+[kickass proposal](https://teom.wordpress.com/2012/03/01/how-to-write-a-kick-ass-proposal-for-google-summer-of-code/)
 
 ## Instructions for mentors
 
 ### Ideas
 
-If you're a developer and you wish to participate in Summer of Code, you
-can do it in two ways: the first and easiest is to make a proposal in
-the
-[ideas](gsoc2021ideas) page. Take a look at what the different OWASP
-Projects needs or what you feel should have. Feel free to submit ideas
-via Pull Request to that page even if you cannot elaborate too much on
-them.
+If you're a developer and you wish to participate in Summer of Code, you can do it in two ways: the first and easiest is to make a proposal in
+the [ideas](gsoc2021ideas) page. Take a look at what the different OWASP Projects needs or what you feel should have. Feel free to submit ideas
+via Pull Request to that page even if you cannot elaborate too much on them.
 
-The second possibility is to be a mentor for a more specific idea. If
-you wish to do that, please read the instructions common to all
-participants and the Summer of Code FAQ. Also, please contact the
-project leader for your application or module and get the go-ahead from
+The second possibility is to be a mentor for a more specific idea. If you wish to do that, please read the instructions common to all
+participants and the Summer of Code FAQ. Also, please contact the project leader for your application or module and get the go-ahead from
 them. Then edit the ideas page, adding your idea.
 
-Your idea proposal should be a brief description of what the project is,
-what the desired goals would be, what the student should know and your
-email address for contact. Please note, though, that the students are
-not required to follow your idea to the letter, so regard your proposal
+Your idea proposal should be a brief description of what the project is, what the desired goals would be, what the student should know and your
+email address for contact. Please note, though, that the students are not required to follow your idea to the letter, so regard your proposal
 as just a suggestion.
 
 ### Mentoring
 
-If you wish to help us even more, you can be an OWASP mentor. We will
-potentially assign a student to you who has never worked on such a large
-project and will need some help. Make sure you're up for the task. When
-subscribing yourself as a mentor, please make sure that your application
-or module maintainer is aware of that. Ask them to send the Summer of
-Code OWASP Administrators an email confirming to know you. This is just
-a formality to make sure you are a real person we can trust -- the
-administrators cannot know all active developers by their Google account
+If you wish to help us even more, you can be an OWASP mentor. We will potentially assign a student to you who has never worked on such a large
+project and will need some help. Make sure you're up for the task. When subscribing yourself as a mentor, please make sure that your application
+or module maintainer is aware of that. Ask them to send the Summer of Code OWASP Administrators an email confirming to know you. This is just
+a formality to make sure you are a real person we can trust -- the administrators cannot know all active developers by their Google account
 ID.
 
-If you would like to get an idea of what is involved in being a good
-mentor, be sure to read the
+If you would like to get an idea of what is involved in being a good mentor, be sure to read the
 [mentoring guide](https://google.github.io/gsocguides/mentor/).
 
-You will be subscribed to a mailing list to discuss ideas. We will also
-require you to read the proposals as they come in and you will be
-allowed to vote on the proposals, according to rules we will publish
-later.
+You will be subscribed to a mailing list to discuss ideas. We will also require you to read the proposals as they come in and you will be
+allowed to vote on the proposals, according to rules we will publish later.
 
-Finally, know that we will never assign you to a project you do not want
-to work on. We will not assign you more projects than you can/want to
-take on eiter. And you will have a backup mentor, just in case something
-unforeseen takes place.
+Finally, know that we will never assign you to a project you do not want to work on. We will not assign you more projects than you can/want to
+take on eiter. And you will have a backup mentor, just in case something unforeseen takes place.
 
 ### Subscribing as mentor
 
 To subscribe as mentor, you need to complete a few easy steps.
 
-- Contact the OWASP GSoC administrators to let them know which project
-  you want to mentor for
-- Log in to
-  [Google Summer of Code Program
-    Site](https://summerofcode.withgoogle.com/)
+- Contact the OWASP GSoC administrators to let them know which project you want to mentor for
+- Log in to [Google Summer of Code Program Site](https://summerofcode.withgoogle.com/)
 - Apply as a mentor for OWASP
-- Subscribe to
-  [https://groups.google.com/d/forum/owasp-gsoc](https://groups.google.com/d/forum/owasp-gsoc)
-
-#### The current list of GSOC 2021 Mentors are:
-
-[TBD]
+- Subscribe to [https://groups.google.com/d/forum/owasp-gsoc](https://groups.google.com/d/forum/owasp-gsoc)
 
 ## Instructions for OWASP Project Leaders
 
-If you are an OWASP Project Leader, you may be contacted by developers
-in your project about an idea they want to submit. You should judge
-whether the idea being proposed coincides with the general goals for
-your OWASP Project. If you feel that is not the case, you should reply
-to your developer and suggest that they modify the proposal. You do not
-need yourself to be a mentor, but we would like you to.
+If you are an OWASP Project Leader, you may be contacted by developers in your project about an idea they want to submit. You should judge
+whether the idea being proposed coincides with the general goals for your OWASP Project. If you feel that is not the case, you should reply
+to your developer and suggest that they modify the proposal. You do not need yourself to be a mentor, but we would like you to.
 
 ## Contact OWASP GSoC Admininstrators
 
-To reach the OWASP administrators for Summer of Code, please send an
-email to the GSOC Administrators below.
+To reach the OWASP administrators for Summer of Code, please send an email to the GSOC Administrators below.
 
 ### The GSOC 2021 Administrators are:
 
@@ -313,4 +201,3 @@ email to the GSOC Administrators below.
 - [Spyros Gasteratos](mailto:spyros.gasteratos@owasp.org)
 - [Fabio Cerullo](mailto:fcerullo@owasp.org)
 - [Harold Blankenship](mailto:harold.blankenship@owasp.org)
-


### PR DESCRIPTION
- Removed boiler plate mentors section which hasn't been completed/updated in years.
- Updated links to new GSoC materials.
- Removed lots of seemingly unnecessary line breaks.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>