### PR TITLE
Rename man-in-the-middle to manipulator-in-the-middle

### DIFF
--- a/pages/attacks/Man-in-the-middle_attack.md
+++ b/pages/attacks/Man-in-the-middle_attack.md
@@ -1,11 +1,11 @@
 ---
 
 layout: col-sidebar
-title: Monster-in-the-middle attack
+title: Manipulator-in-the-middle attack
 author: 
 contributors: 
-permalink: /attacks/Monster-in-the-middle_attack
-tags: attack, Monster-in-the-middle attack, MITM
+permalink: /attacks/Manipulator-in-the-middle_attack
+tags: attack, Manipulator-in-the-middle attack, MITM
 auto-migrated: 1
 
 ---
@@ -14,7 +14,7 @@ auto-migrated: 1
 
 ## Description
 
-The monster-in-the middle attack (MITM) intercepts a communication between two
+The Manipulator-in-the middle attack (MITM) intercepts a communication between two
 systems. For example, in an http transaction the target is the TCP
 connection between client and server. Using different techniques, the
 attacker splits the original TCP connection into 2 new connections, one

--- a/pages/attacks/Man-in-the-middle_attack.md
+++ b/pages/attacks/Man-in-the-middle_attack.md
@@ -1,11 +1,11 @@
 ---
 
 layout: col-sidebar
-title: Man-in-the-middle attack
+title: Monster-in-the-middle attack
 author: 
 contributors: 
-permalink: /attacks/Man-in-the-middle_attack
-tags: attack, Man-in-the-middle attack
+permalink: /attacks/Monster-in-the-middle_attack
+tags: attack, Monster-in-the-middle attack, MITM
 auto-migrated: 1
 
 ---
@@ -14,7 +14,7 @@ auto-migrated: 1
 
 ## Description
 
-The man-in-the middle attack intercepts a communication between two
+The monster-in-the middle attack (MITM) intercepts a communication between two
 systems. For example, in an http transaction the target is the TCP
 connection between client and server. Using different techniques, the
 attacker splits the original TCP connection into 2 new connections, one


### PR DESCRIPTION
While the initialism "MITM" remains the same, "manipulator-in-the-middle" is a gender-neutral, non-exclusionary alternative for "man-in-the-middle".

Current use:

- Search engines find MitM content for the term "monster-in-the-middle"
- CloudFlare already calls MitM "monster-in-the-middle" in their MitM Engine project and associated writing.
- https://www.zaproxy.org/docs/desktop/start/features/intercept/
- https://portswigger.net/daily-swig/mitm

Edit: Added references from comments below