### PR TITLE
fix: auto-migrated content

### DIFF
--- a/pages/attacks/CSV_Injection.md
+++ b/pages/attacks/CSV_Injection.md
@@ -2,11 +2,10 @@
 
 layout: col-sidebar
 title: CSV Injection
-author: 
-contributors: 
+author: Timo Goosen, Albinowax
+contributors: kingthorin
 permalink: /attacks/CSV_Injection
 tags: attack, vulnerability, CSV Injection
-auto-migrated: 1
 
 ---
 
@@ -16,24 +15,24 @@ CSV Injection, also known as Formula Injection, occurs when websites
 embed untrusted input inside CSV files.
 
 When a spreadsheet program such as Microsoft Excel or LibreOffice Calc
-is used to open a CSV, any cells starting with '=' will be interpreted
+is used to open a CSV, any cells starting with `=` will be interpreted
 by the software as a formula. Maliciously crafted formulas can be used
 for three key attacks:
 
-- Hijacking the user's computer by exploiting vulnerabilities in the spreadsheet software, such as CVE-2014-3524
-- Hijacking the user's computer by exploiting the user's tendency to ignore security warnings in spreadsheets that they downloaded from their own website
+- Hijacking the user's computer by exploiting vulnerabilities in the spreadsheet software, such as CVE-2014-3524.
+- Hijacking the user's computer by exploiting the user's tendency to ignore security warnings in spreadsheets that they downloaded from their own website.
 - Exfiltrating contents from the spreadsheet, or other open spreadsheets.
 
 This attack is difficult to mitigate, and explicitly disallowed from
 quite a few bug bounty programs. To remediate it, ensure that no cells
 begin with any of the following characters:
 
-- Equals to ("=")
-- Plus ("+")
-- Minus ("-")
-- At ("@")
-- Tab (0x09)
-- Carriage return (0x0D)
+- Equals to (`=`)
+- Plus (`+`)
+- Minus (`-`)
+- At (`@`)
+- Tab (`0x09`)
+- Carriage return (`0x0D`)
 
 Alternatively, prepend each cell field with a single quote, so that their content will be read as text by the spreadsheet editor.
 

--- a/pages/attacks/Cryptanalysis.md
+++ b/pages/attacks/Cryptanalysis.md
@@ -3,10 +3,9 @@
 layout: col-sidebar
 title: Cryptanalysis
 author: 
-contributors: 
+contributors: Rezos, KristenS, kingthorin
 permalink: /attacks/Cryptanalysis
 tags: attack, Cryptanalysis
-auto-migrated: 1
 
 ---
 
@@ -21,15 +20,10 @@ not in the cryptographic algorithm itself, but rather in how it is
 applied that makes cryptanalysis successful. An attacker may have other
 goals as well, such as:
 
-  - Total Break - Finding the secret key.
-  - Gobal Deduction - Finding a functionally equivalent algorithm for
-    encryption and decryption that does not require knowledge of the
-    secret key.
-  - Information Deduction - Gaining some information about plaintexts or
-    ciphertexts that was not previously known.
-  - Distinguishing Algorithm - The attacker has the ability to
-    distinguish the output of the encryption (ciphertext) from a random
-    permutation of bits.
+- Total Break - Finding the secret key.
+- Gobal Deduction - Finding a functionally equivalent algorithm for encryption and decryption that does not require knowledge of the secret key.
+- Information Deduction - Gaining some information about plaintexts or ciphertexts that was not previously known.
+- Distinguishing Algorithm - The attacker has the ability to distinguish the output of the encryption (ciphertext) from a random permutation of bits.
 
 The goal of the attacker performing cryptanalysis will depend on the
 specific needs of the attacker in a given attack context. In most cases,
@@ -37,10 +31,6 @@ if cryptanalysis is successful at all, an attacker will not be able to
 go past being able to deduce some information about the plaintext (goal
 3). However, that may be sufficient for an attacker, depending on the
 context.
-
-## Risk Factors
-
-TBD
 
 ## Examples
 
@@ -67,45 +57,18 @@ ciphers as they are all resilient to it (unless this is a very bad case
 of a homegrown encryption algorithm). This example is just here to
 illustrate a rudimentary example of cryptanalysis.
 
-## Related [Threat Agents](Threat_Agents "wikilink")
-
-  - [:Category:Authentication](:Category:Authentication "wikilink")
-
-## Related [Attacks](https://owasp.org/www-community/attacks/)
-
-  - [Brute force attack](Brute_force_attack "wikilink")
-
-## Related [Vulnerabilities](https://owasp.org/www-community/vulnerabilities/)
-
-  - TBD
-
 ## Related [Controls](https://owasp.org/www-community/controls/)
-
-  - [Encryption](Encryption "wikilink")
-  - [Cryptography](Cryptography "wikilink")
-  - [Randomization](Randomization "wikilink")
 
 Use proven cryptographic algorithms with recommended key sizes.
 
 Ensure that the algorithms are used properly. That means:
 
-  - Not rolling out your own crypto; Use proven algorithms and
-    implementations.
-  - Choosing initialization vectors with sufficiently random numbers
-  - Generating key material using good sources of randomness and
-    avoiding known weak keys
-  - Using proven protocols and their implementations.
-  - Picking the most appropriate cryptographic algorithm for your usage
-    context and data\]\]
+- Not rolling out your own crypto; Use proven algorithms and implementations.
+- Choosing initialization vectors with sufficiently random numbers
+- Generating key material using good sources of randomness and avoiding known weak keys
+- Using proven protocols and their implementations.
+- Picking the most appropriate cryptographic algorithm for your usage context and data
 
 ## References
 
-  - <http://capec.mitre.org/data/definitions/97.html> - this same
-    information and much more
-  - <http://www.rsa.com/rsalabs/node.asp?id=2199> - more detailed and
-    modern description of cryptanalysis attack
-
-[Category:OWASP ASDR Project](Category:OWASP_ASDR_Project "wikilink")
-[Category:Probabilistic
-Techniques](Category:Probabilistic_Techniques "wikilink")
-[Category:Attack](Category:Attack "wikilink")
+- [CAPEC - Cryptanalysis](http://capec.mitre.org/data/definitions/97.html)

--- a/pages/attacks/Custom_Special_Character_Injection.md
+++ b/pages/attacks/Custom_Special_Character_Injection.md
@@ -2,8 +2,8 @@
 
 layout: col-sidebar
 title: Custom Special Character Injection
-author: 
-contributors: 
+author: Rezos
+contributors: Weilin Zhong, KristenS, Alan Jex, kingthorin 
 permalink: /attacks/Custom_Special_Character_Injection
 tags: attack, Custom Special Character Injection
 auto-migrated: 1
@@ -20,54 +20,27 @@ representation that is used by the product. That allows attackers to
 modify the syntax, content, or commands before they are processed by the
 end system.
 
-## Risk Factors
-
-TBD
-
 ## Examples
 
-**Example 1**
+### Example 1
 
 A simple example is an application which executes almost everything
 which is passed to it from the current terminal by the user without
-sanitazing and blocking user input. If the application doesn't implement
+sanitizing and blocking user input. If the application doesn't implement
 appropriate signals handling, we may interrupt or suspend program
 execution by sending respectively `Ctrl+C (^C)` or `Ctrl+Z (^Z)`
 combinations. These combinations are sending signals to the application.
 In the first case it's `SIGINT` and in the second it's `SIGSTOP` signal.
 
-**Example 2**
+### Example 2
 
 The classic example, often used by the IRC warriors/bandits, was
 disconnecting modem users by sending to them a special sequence of
-characters. Sending via any protocol (IP) "*+++ATH0*" sequence caused
+characters. Sending via any protocol (IP) `*+++ATH0*` sequence caused
 some modems to interpret this sequence as a disconnect command. So all
 that had to be done was to send the sequence on an IRC channel, which in
 effect forced vulnerable modems to disconnect.
 
-## Related [Threat Agents](Threat_Agents "wikilink")
-
-- [Logic/time bomb](Logic/time_bomb "wikilink")
-
 ## Related [Attacks](https://owasp.org/www-community/attacks/)
 
 - [Log forging](https://owasp.org/www-community/attacks/Log_Injection)
-
-## Related [Vulnerabilities](https://owasp.org/www-community/vulnerabilities/)
-
-TBD
-
-## Related [Controls](https://owasp.org/www-community/controls/)
-
-- [:Category:Input Validation](:Category:Input_Validation "wikilink")
-- [Output Validation](Output_Validation "wikilink")
-- [Canonicalization](Canonicalization "wikilink")
-
-## References
-
-TBD
-
-[Category:OWASP ASDR Project](Category:OWASP_ASDR_Project "wikilink")
-[Category:Injection](https://owasp.org/www-community/Injection_Flaws) 
-[Category:Resource Manipulation](Category:Resource_Manipulation "wikilink")
-[Category:Attack](Category:Attack "wikilink")

--- a/pages/attacks/Denial_of_Service.md
+++ b/pages/attacks/Denial_of_Service.md
@@ -2,11 +2,10 @@
 
 layout: col-sidebar
 title: Denial of Service
-author: 
-contributors: 
+author: Nsrav
+contributors: KristenS, Adar Weidman, psiinon, Adrew Smith, Jkurucar, kingthorin
 permalink: /attacks/Denial_of_Service
 tags: attack, Denial of Service
-auto-migrated: 1
 
 ---
 
@@ -69,9 +68,11 @@ performance.
 
 The following is a simple example of vulnerable code in Java:
 
-`String TotalObjects = request.getParameter(“numberofobjects”);`
-`int NumOfObjects = Integer.parseInt(TotalObjects);`
-`ComplexObject[] anArray = new ComplexObject[NumOfObjects];  // wrong!`
+```java
+String TotalObjects = request.getParameter(“numberofobjects”);
+int NumOfObjects = Integer.parseInt(TotalObjects);
+ComplexObject[] anArray = new ComplexObject[NumOfObjects];  // wrong!
+```
 
 ### DoS User Input as a Loop Counter
 
@@ -82,19 +83,21 @@ server.
 
 The following is an example of vulnerable code in Java:
 
-`public class MyServlet extends ActionServlet {`
-`   public void doPost(HttpServletRequest request, HttpServletResponse response)`
-`          throws ServletException, IOException {`
-`          . . . `
-`          String [] values = request.getParameterValues("CheckboxField");`
-`      // Process the data without length check for reasonable range – wrong!`
-`          for ( int i=0; i<values.length; i++) {`
-`                // lots of logic to process the request`
-`         }`
-`         . . . `
-`   }`
-`    . . . `
-`}`
+```java
+public class MyServlet extends ActionServlet {
+   public void doPost(HttpServletRequest request, HttpServletResponse response)
+          throws ServletException, IOException {
+          . . .
+          String [] values = request.getParameterValues("CheckboxField");
+      // Process the data without length check for reasonable range – wrong!
+          for ( int i=0; i<values.length; i++) {
+                // lots of logic to process the request
+         }
+         . . .
+   }
+    . . .
+}
+```
 
 As we can see in this simple example, the user has control over the loop
 counter. If the code inside the loop is very demanding in terms of
@@ -108,60 +111,56 @@ If an error occurs in the application that prevents the release of an
 in-use resource, it can become unavailable for further use. Possible
 examples include:
 
-  - An application locks a file for writing, and then an exception
-    occurs but does not explicitly close and unlock the file
-  - Memory leaking in languages where the developer is responsible for
-    memory management such as C & C++. In the case where an error causes
-    normal logic flow to be circumvented, the allocated memory may not
-    be removed and may be left in such a state that the garbage
-    collector does not know it should be reclaimed
-  - Use of DB connection objects where the objects are not being freed
-    if an exception is thrown. A number of such repeated requests can
-    cause the application to consume all the DB connections, as the code
-    will still hold the open DB object, never releasing the resource.
+  - An application locks a file for writing, and then an exception occurs but does not explicitly close and unlock the file
+  - Memory leaking in languages where the developer is responsible for memory management such as C & C++. In the case where an error causes normal logic flow to be circumvented, the allocated memory may not be removed and may be left in such a state that the garbage collector does not know it should be reclaimed
+  - Use of DB connection objects where the objects are not being freed if an exception is thrown. A number of such repeated requests can cause the application to consume all the DB connections, as the code will still hold the open DB object, never releasing the resource.
 
 The following is an example of vulnerable code in Java. In the example,
 both the Connection and the CallableStatement should be closed in a
 finally block.
 
-`public class AccountDAO {`
-`    … …`
-`    public void createAccount(AccountInfo acct)  `
-`                 throws AcctCreationException {`
-`       … …`
-`           try {`
-`            Connection conn = DAOFactory.getConnection();`
-`            CallableStatement  calStmt = conn.prepareCall(…);`
-`          …  … `
-`           calStmt.executeUpdate();`
-`           calStmt.close();`
-`          conn.close();`
-`       }  catch (java.sql.SQLException e) {`
-`            throw AcctCreationException (...);`
-`       }`
-`    }`
-`}`
+```
+public class AccountDAO {
+    … …
+    public void createAccount(AccountInfo acct)
+                 throws AcctCreationException {
+       … …
+           try {
+            Connection conn = DAOFactory.getConnection();
+            CallableStatement  calStmt = conn.prepareCall(…);
+          …  … 
+           calStmt.executeUpdate();
+           calStmt.close();
+          conn.close();
+       }  catch (java.sql.SQLException e) {
+            throw AcctCreationException (...);
+       }
+    }
+}
+```
 
 ### DoS Buffer Overflows
 
 Any language where the developer has direct responsibility for managing
 memory allocation, most notably C & C++, has the potential for a [Buffer
-Overflow](Buffer_Overflow "wikilink"). While the most serious risk
+Overflow](Buffer_Overflow_attack). While the most serious risk
 related to a buffer overflow is the ability to execute arbitrary code on
 the server, the first risk comes from the denial of service that can
 happen if the application crashes.
 
 The following is a simplified example of vulnerable code in C:
 
-`void overflow (char *str) {`
-`   char buffer[10];`
-`   strcpy(buffer, str); // Dangerous!`
-`}`
+```c
+void overflow (char *str) {
+   char buffer[10];
+   strcpy(buffer, str); // Dangerous!
+}
 
-`int main () {`
-`  char *str = "This is a string that is larger than the buffer of 10";`
-`  overflow(str);`
-`}`
+int main () {
+  char *str = "This is a string that is larger than the buffer of 10";
+  overflow(str);
+}
+```
 
 If this code example were executed, it would cause a segmentation fault
 and dump core. The reason is that strcpy would try to copy 53 characters
@@ -197,39 +196,10 @@ choose their own account names, to using systems such as CAPTCHA, and
 the like. Each enterprise will need to balance these risks and benefits,
 but not all of the details of those decisions are covered here.
 
-## Related [Threat Agents](Threat_Agents "wikilink")
-
-  - [:Category:Logical Attacks](:Category:Logical_Attacks "wikilink")
-
 ## Related [Attacks](https://owasp.org/www-community/attacks/)
 
-  - [Resource Injection](https://owasp.org/www-community/attacks/Resource_Injection)
-  - [Setting Manipulation](Setting_Manipulation "wikilink")
-  - [Regular expression Denial of Service -
-    ReDoS](Regular_expression_Denial_of_Service_-_ReDoS "wikilink")
-  - [Cash Overflow](Cash_Overflow "wikilink")
-
-## Related [Vulnerabilities](https://owasp.org/www-community/vulnerabilities/)
-
-  - [:Category: Input Validation
-    Vulnerability](:Category:_Input_Validation_Vulnerability "wikilink")
-  - [:Category: API Abuse](:Category:_API_Abuse "wikilink")
-
-## Related [Controls](https://owasp.org/www-community/controls/)
-
-  - [Blocking Brute Force
-    Attacks](Blocking_Brute_Force_Attacks "wikilink")
-  - [Memory Management](Memory_Management "wikilink")
+- [Resource Injection](https://owasp.org/www-community/attacks/Resource_Injection)
 
 ## References
 
-  - <http://capec.mitre.org/data/index.html> - Denial of Service through
-    Resource Depletion
-
-[Category:OWASP ASDR Project](Category:OWASP_ASDR_Project "wikilink")
-[need content](Category:FIXME "wikilink") [not a threat
-agent](Category:FIXME "wikilink") [Category:
-Spoofing](Category:_Spoofing "wikilink") [Category: Probabilistic
-Techniques](Category:_Probabilistic_Techniques "wikilink") [Category:
-Resource Depletion](Category:_Resource_Depletion "wikilink")
-[Category:Attack](Category:Attack "wikilink")
+- [Denial of Service through Resource Depletion](http://capec.mitre.org/data/index.html)


### PR DESCRIPTION
Misc auto-migrated content fixes. Code fencing, links, etc. Add author/contributor info based on wiki.owasp.org info.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>