### PR TITLE
Field seps can be used to start formulas in the middle of user input

### DIFF
--- a/pages/attacks/CSV_Injection.md
+++ b/pages/attacks/CSV_Injection.md
@@ -34,7 +34,10 @@ begin with any of the following characters:
 - Tab (`0x09`)
 - Carriage return (`0x0D`)
 
+Keep in mind that it is not sufficient to make sure that the untrusted user input does not start with these characters. You also need to take care of the field separator (e.g., '`,`', or '`;`'), as attackers could use this to start a new cell and then have the dangerous character in the middle of the user input, but at the beginning of a cell.
+
 Alternatively, prepend each cell field with a single quote, so that their content will be read as text by the spreadsheet editor.
+
 
 For further information, please refer to the following articles:
 


### PR DESCRIPTION
As it was shown recently with the german luca-app, developers following this guide made the mistake to filter out the listed dangerous characters at the beginning of the user input, but did not take care of the field separators. Therefore an attacker was able to inject another field and have an equal sign (`=`) at the beginning of the cell, despite the fact of it not being at the beginning of the untrusted user input.
I tried to explain this in a short addition to the cheat sheet to make sure that following developers that follow the cheat sheet do not fall into this trap.