### PR TITLE
Describe login CSRF

### DIFF
--- a/pages/attacks/cross-site-request-forgery.md
+++ b/pages/attacks/cross-site-request-forgery.md
@@ -3,7 +3,7 @@
 layout: col-sidebar
 title: Cross Site Request Forgery (CSRF)
 author: KirstenS
-contributors: Dave Wichers, Davisnw, Paul Petefish, Adar Weidman, Michael Brooks, Ahsan Mir, Dc, D0ubl3 h3lix, Jim Manico, Robert Gilbert, Tgondrom, Pawel Krawczyk, Brandt, A V Minhaz, Kevin Lorenzo, Andrew Smith, Christina Schelin, Ari Elias-Bachrach, Sarciszewski, kingthorin
+contributors: Dave Wichers, Davisnw, Paul Petefish, Adar Weidman, Michael Brooks, Ahsan Mir, Dc, D0ubl3 h3lix, Jim Manico, Robert Gilbert, Tgondrom, Pawel Krawczyk, Brandt, A V Minhaz, Kevin Lorenzo, Andrew Smith, Christina Schelin, Ari Elias-Bachrach, Sarciszewski, kingthorin, Ben Spatafora
 permalink: /attacks/csrf
 tags: attack, CSRF
 
@@ -68,19 +68,28 @@ ESAPI](http://www.owasp.org/index.php/Category:OWASP_Enterprise_Security_API).
 
 CSRF is an attack that tricks the victim into submitting a malicious
 request. It inherits the identity and privileges of the victim to
-perform an undesired function on the victim's behalf. For most sites,
-browser requests automatically include any credentials associated with
-the site, such as the user's session cookie, IP address, Windows domain
-credentials, and so forth. Therefore, if the user is currently
-authenticated to the site, the site will have no way to distinguish
-between the forged request sent by the victim and a legitimate request
-sent by the victim.
+perform an undesired function on the victim's behalf (though note that
+this is not true of login CSRF, a special form of the attack described
+below). For most sites, browser requests automatically include any
+credentials associated with the site, such as the user's session
+cookie, IP address, Windows domain credentials, and so forth.
+Therefore, if the user is currently authenticated to the site, the site
+will have no way to distinguish between the forged request sent by the
+victim and a legitimate request sent by the victim.
 
 CSRF attacks target functionality that causes a state change on the
 server, such as changing the victim's email address or password, or
 purchasing something. Forcing the victim to retrieve data doesn't
 benefit an attacker because the attacker doesn't receive the response,
 the victim does. As such, CSRF attacks target state-changing requests.
+
+An attacker can use CSRF to obtain the victim's private data via a
+special form of the attack, known as login CSRF. The attacker forces
+a non-authenticated user to log in to an account the attacker controls.
+If the victim does not realize this, they may add personal data—such as
+credit card information—to the account. The attacker can then log back
+into the account to view this data, along with the victim's activity
+history on the web application.
 
 It's sometimes possible to store the CSRF attack on the vulnerable site
 itself. Such vulnerabilities are called "stored CSRF flaws". This can be


### PR DESCRIPTION
The article gives the impression that CSRF is only a threat to authenticated users ("It inherits the identity and privileges of the victim"), but login CSRF targets non-authenticated users.