### PR TITLE
Remove wikto

### DIFF
--- a/_data/tools.json
+++ b/_data/tools.json
@@ -612,15 +612,6 @@
       "type": "DAST"
    },
    {
-      "title": "Wikto",
-      "url": "http://www.sensepost.com/research/wikto/",
-      "owner": "Sensepost",
-      "license": "Open Source",
-      "platforms": "Windows",
-      "note": null,
-      "type": "DAST"
-   },
-   {
       "title": "w3af",
       "url": "http://www.w3af.org/",
       "owner": "w3af.org",


### PR DESCRIPTION
The listed URL was no longer valid, plus searching for it shows it hasn't seen activity in 6-10 years.