### PR TITLE
Additional anti-decompile techniques

### DIFF
--- a/pages/controls/Bytecode_obfuscation.md
+++ b/pages/controls/Bytecode_obfuscation.md
@@ -57,6 +57,7 @@ tampering. Some typical examples of obfuscation techniques include:
 - **Dummy Code Insertion** inserts code that does not affect the program’s logic, but breaks decompilers or makes reverse-engineered code harder to analyze.
 - **Unused Code and Metadata Removal** prunes out debug, non-essential metadata and used code from applications to reduce the information available to an attacker.
 - **Class file encryption** requires the JVM to decrypt the java executable before running confusing decompilers. Unlike some of the other transforms, this one is easy to circumvent by modifing the local JVM to simply write the executable to disk in its unencrypted form. See: [Javaworld article](http://www.javaworld.com/javaworld/javaqa/2003-05/01-qa-0509-jcrypt.html?page=2)).
+- **Targeting Decompiler Flaws** in order to cause reverse enginnering tools or analysis of the bytecode to fail. See: [Stop Decompiling My Java](https://github.com/ItzSomebody/stopdecompilingmyjava)
 
 ### What obfuscation tools are available?
 


### PR DESCRIPTION
This PR adds the bullet point `Targeting Decompiler Flaws` which is elaborated upon in the linked repo: [StopDecompilingMyJava](https://github.com/ItzSomebody/stopdecompilingmyjava) _(Which also links to another similar repo including more targeted techniques)_

When developing my own tools for Java reverse engineering I've stumbled upon these sorts of issues more often in recent years so it may be useful to mention these sorts of measures.