### PR TITLE
Add section regarding automated Java bytecode deobfuscation

### DIFF
--- a/pages/controls/Bytecode_obfuscation.md
+++ b/pages/controls/Bytecode_obfuscation.md
@@ -28,10 +28,10 @@ code can be reverse-engineered with enough skill, time and effort.
 However, for some platforms such as Java, Android, or.NET, free
 decompilers can easily reverse-engineer source code from an executable
 or library with no real time or effort. Automated bytecode obfuscation
-makes reverse-engineering a program difficult and economically
-unfeasible. Other advantages could include helping to protect licensing
-mechanisms and unauthorized access, hiding vulnerabilities and shrinking
-the size of the executable.
+can make reverse-engineering a program difficult but certainly not impossible.
+In simpler cases it can be done with enough patience and the correct tools. 
+Other advantages could include helping to protect licensing mechanisms and
+unauthorized access, hiding vulnerabilities and shrinking the size of the executable.
 
 ### How to recover Source Code from Bytecode?
 

--- a/pages/controls/Bytecode_obfuscation.md
+++ b/pages/controls/Bytecode_obfuscation.md
@@ -58,6 +58,15 @@ tampering. Some typical examples of obfuscation techniques include:
 - **Unused Code and Metadata Removal** prunes out debug, non-essential metadata and used code from applications to reduce the information available to an attacker.
 - **Class file encryption** requires the JVM to decrypt the java executable before running confusing decompilers. Unlike some of the other transforms, this one is easy to circumvent by modifing the local JVM to simply write the executable to disk in its unencrypted form. See: [Javaworld article](http://www.javaworld.com/javaworld/javaqa/2003-05/01-qa-0509-jcrypt.html?page=2)).
 
+### How to automatically clean up obfuscated bytecode?
+
+While there are tools that would allow a person with enough patience and skill to 
+manually deobfuscate these techniques themselves, these processes can also be automated
+with some open source tools. 
+
+- [Java-Deobfuscator](https://github.com/java-deobfuscator/deobfuscator) - A command line tool providing automated reversal of commerical obfuscation patterns.
+- [Threadtear](https://github.com/GraxCode/threadtear/) - A UI tool including automated reversal of commercial obfuscation patterns, plus preview decompilation of the results and more useful tooling.
+
 ### What obfuscation tools are available?
 
 You can find popular tools for Java bytecode obfuscation below, or simply enter `java obfuscator` in your favorite search engine.

--- a/pages/controls/Bytecode_obfuscation.md
+++ b/pages/controls/Bytecode_obfuscation.md
@@ -64,8 +64,8 @@ While there are tools that would allow a person with enough patience and skill t
 manually deobfuscate these techniques themselves, these processes can also be automated
 with some open source tools. 
 
-- [Java-Deobfuscator](https://github.com/java-deobfuscator/deobfuscator) - A command line tool providing automated reversal of commerical obfuscation patterns.
-- [Threadtear](https://github.com/GraxCode/threadtear/) - A UI tool including automated reversal of commercial obfuscation patterns, plus preview decompilation of the results and more useful tooling.
+- [Java-Deobfuscator](https://github.com/java-deobfuscator/deobfuscator) - A command line tool providing automated reversal of common obfuscation patterns.
+- [Threadtear](https://github.com/GraxCode/threadtear/) - A UI tool including automated reversal of common obfuscation patterns, plus preview decompilation of the results and more useful tooling.
 
 ### What obfuscation tools are available?
 


### PR DESCRIPTION
The article initially states:

> Automated bytecode obfuscation makes reverse-engineering a program difficult and economically unfeasible.

In some cases a majority of the complex work can be automated. So I included a brief section with links to some tools capable of this.