### PR TITLE
Update Further Reading links in Static_Code_Analysis.md

### DIFF
--- a/pages/controls/Static_Code_Analysis.md
+++ b/pages/controls/Static_Code_Analysis.md
@@ -190,5 +190,5 @@ environment and whether it is configured securely.
 
 ## Further Reading
 
-- [RIPS](http://www.php-security.org/downloads/rips.pdf)
-- [pixy](http://www.seclab.tuwien.ac.at/papers/pixy.pdf)
+- [RIPS](https://sourceforge.net/projects/rips-scanner/)
+- [pixy](http://seclab.nu/static/publications/ssp2006pixy.pdf)


### PR DESCRIPTION
The links for RIPS and pixy that were previously added under the "Further Reading" section appear to be outdated.