### PR TITLE
 Prevent code injection

### DIFF
--- a/.github/workflows/validate-tools-json.yml
+++ b/.github/workflows/validate-tools-json.yml
@@ -5,6 +5,10 @@ on:
     paths:
     - '_data/tools.json'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   schema-check:
     runs-on: ubuntu-latest
@@ -26,15 +30,8 @@ jobs:
       run: |
         ajv validate -s tools_schema.json -d _data/tools.json --all-errors --errors=text --verbose=true -c=ajv-formats 1> log.txt 2>&1
     - name: Show Validation Issues
-      id: validation
       if: failure()
-      run: |
-        cat log.txt
-        ISSUES=$(cat log.txt)
-        ISSUES="${ISSUES//'%'/'%25'}"
-        ISSUES="${ISSUES//$'\n'/'%0A'}"
-        ISSUES="${ISSUES//$'\r'/'%0D'}"
-        echo ::set-output name=ISSUES::$ISSUES
+      run: cat log.txt
     - name: Attach Log
       uses: actions/upload-artifact@v2
       if: failure()
@@ -47,9 +44,12 @@ jobs:
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
+          const fs = require("fs");
+          const logPath = `${process.env.GITHUB_WORKSPACE}/log.txt`;
+          const logString = fs.readFileSync(logPath).toString().trimEnd();
           github.issues.createComment({
             issue_number: ${{ github.event.number }},
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: `**The following issues were identified, when validatoin against the [schema](https://github.com/OWASP/www-community/blob/master/tools_schema.json):**\n\n<details><summary>Summary (click the triangle/control to the left to expand)</summary>\n\n\`\`\`\n${{ steps.validation.outputs.ISSUES }}\n\`\`\`\n\n</details>`
+            body: `**The following issues were identified, when validating against the [schema](https://github.com/OWASP/www-community/blob/master/tools_schema.json):**\n\n<details><summary>Summary (click the triangle/control to the left to expand)</summary>\n\n\`\`\`\n${logString}\n\`\`\`\n\n</details>`
           })


### PR DESCRIPTION
* Read errors from log file instead of injecting them into javascript
* Use minimum permissions required