### PR TITLE
fix typo in Java code

### DIFF
--- a/pages/vulnerabilities/Use_of_hard-coded_password.md
+++ b/pages/vulnerabilities/Use_of_hard-coded_password.md
@@ -94,7 +94,7 @@ In Java:
 ```java
 int verifyAdmin(String password) {
 
-  if (password.equals("Mew!")) {
+  if (!password.equals("Mew!")) {
     return 0;
   }
   //Diagnostic Mode


### PR DESCRIPTION
I believe there is a typo in the Java code. In the C code strcmp is used, which returns 0 (false) when there is a match, in the Java code String.equals is used which returns true when there is a match, therefore we need a negation to ensure the logic is the same.