### PR TITLE
Add first Juice Shop idea and introduce project size badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ _site/
 # -------
 *.project
 *.settings
+
+# IntelliJ
+# --------
+.idea/

--- a/pages/initiatives/gsoc/gsoc2022.md
+++ b/pages/initiatives/gsoc/gsoc2022.md
@@ -151,7 +151,7 @@ The KDE project has also released a guide on how to write a
 ### Ideas
 
 If you're a developer and you wish to participate in Summer of Code, you can do it in two ways: the first and easiest is to make a proposal in
-the [ideas](gsoc2021ideas) page. Take a look at what the different OWASP Projects needs or what you feel should have. Feel free to submit ideas
+the [ideas](gsoc2022ideas) page. Take a look at what the different OWASP Projects needs or what you feel should have. Feel free to submit ideas
 via Pull Request to that page even if you cannot elaborate too much on them.
 
 The second possibility is to be a mentor for a more specific idea. If you wish to do that, please read the instructions common to all

--- a/pages/initiatives/gsoc/gsoc2022ideas.md
+++ b/pages/initiatives/gsoc/gsoc2022ideas.md
@@ -12,6 +12,14 @@ permalink: /initiatives/gsoc/gsoc2022ideas
 
 ##### [Explanation of Ideas]
 
+![Preferred for "Medium" GSoC 2022 project](https://img.shields.io/badge/medium%20size%20(~175h)-preferred-green)
+![Possible for "Medium" GSoC 2022 project](https://img.shields.io/badge/medium%20size%20(~175h)-possible-yellow)
+![Not recommended for "Medium" GSoC 2022 project](https://img.shields.io/badge/medium%20size%20(~175h)-not%20recommended-red)
+
+![Preferred for "Large" GSoC 2022 project](https://img.shields.io/badge/large%20size%20(~350h)-preferred-green)
+![Possible for "Large" GSoC 2022 project](https://img.shields.io/badge/large%20size%20(~350h)-possible-yellow)
+![Not recommended for "Large" GSoC 2022 project](https://img.shields.io/badge/large%20size%20(~350h)-not%20recommended-red)
+
 ##### [Expected Results]
 
 ##### [Getting Started]
@@ -28,3 +36,73 @@ Tips to get you started in no particular order:
 
 ## List of Project Ideas
 
+### [OWASP Juice Shop](https://owasp-juice.shop)
+
+OWASP Juice Shop is probably the most modern and sophisticated insecure
+web application! It can be used in security trainings, awareness demos,
+CTFs and as a guinea pig for security tools! Juice Shop encompasses
+vulnerabilities from the entire OWASP Top Ten along with many other
+security flaws found in real-world applications!
+
+To receive early feedback please:
+- put your proposal on Google Docs and submit it to the OWASP
+  Organization on Google's GSoC page in "Draft Shared" mode.
+- Please pick "juice shop" as Proposal Tag to make them easier to find
+  for us. Thank you!
+
+##### Explanation of Ideas
+
+###### Score Board UI/UX
+
+![Possible for "Medium" GSoC 2022 project](https://img.shields.io/badge/medium%20size%20(~175h)-possible-yellow)
+![Preferred for "Large" GSoC 2022 project](https://img.shields.io/badge/large%20size%20(~350h)-preferred-green)
+
+Juice Shop's existing Score Board has been rewritten from scratch once
+when the project moved from AngularJS/Bootstrap to Angular/Material.
+Since then, new features, filters and information has been added to it
+over the years. It has grown to a point where it can be confusing for
+beginners. It also became pretty slow to render over time.
+
+After a big facelift project for all the other UI screens, the Score
+Board now is the one screen left to require some special attention. As
+it is the heart and soul of the Juice Shop, any redesign or usability
+improvements must be thoroughly tested and strive for the best possible
+user experience.
+
+###### Your own idea
+
+You have an awesome idea to improve OWASP Juice Shop that is not on this
+list? Great, please submit it!
+
+##### Expected Results
+
+* A new feature or improvement of an existing one that makes OWASP Juice
+  Shop even better
+* Your code follows our existing styleguides and passes all existing
+  quality gates regarding code smells, test coverage etc.
+* Code that you write comes with automated tests that fit into
+  [our available test suites](https://pwning.owasp-juice.shop/part3/contribution.html#testing).
+
+##### Getting started
+
+* Make sure your JavaScript/TypeScript is sufficient to work on the
+  Juice Shop codebase. Check our
+  [Codebase 101](https://pwning.owasp-juice.shop/part3/codebase.html)
+  here. Students with some experience with (or willingness to learn)
+  Angular and NodeJS/Express are usually prefered.
+* Read our
+  [Contribution Guidelines](https://pwning.owasp-juice.shop/part3/contribution.html)
+  very carefully. Best make some small contributions before GSoC, so we
+  can see how you work and help you dive into the code even better.
+* Get in touch with
+  [Bjoern Kimminich](mailto:bjoern.kimminich@owasp.org) to discuss any
+  of the listed or your own idea for GSoC!
+
+##### Mentors
+
+* [Bjoern Kimminich](mailto:bjoern.kimminich@owasp.org) - OWASP Juice
+  Shop Project Leader
+* Jannik Hollenbach - OWASP Juice Shop Core Team
+* Timo Pagel - OWASP Juice Shop Core Team
+
+----

--- a/pages/initiatives/gsoc/gsoc2022ideas.md
+++ b/pages/initiatives/gsoc/gsoc2022ideas.md
@@ -21,7 +21,7 @@ permalink: /initiatives/gsoc/gsoc2022ideas
 
 Tips to get you started in no particular order:
 - Read the
-  [Student Guidelines](gsoc2021).
+  [Student Guidelines](gsoc2022).
 - Check our
   [github organization](https://github.com/OWASP).
 - Contact one of the project mentors below.


### PR DESCRIPTION
As GSoC now differentiates ["medium" (~175h) and "large" (~350h] projects](https://opensource.googleblog.com/2021/11/expanding-google-summer-of-code-in-2022.html) it could be helpful to applicants to know what the expectation or recommendation for a project is from the mentors point of view. I would like to propose to consistently use these badges for that purpose across project ideas:

![Preferred for "Medium" GSoC 2022 project](https://img.shields.io/badge/medium%20size%20(~175h)-preferred-green)
![Possible for "Medium" GSoC 2022 project](https://img.shields.io/badge/medium%20size%20(~175h)-possible-yellow)
![Not recommended for "Medium" GSoC 2022 project](https://img.shields.io/badge/medium%20size%20(~175h)-not%20recommended-red)

![Preferred for "Large" GSoC 2022 project](https://img.shields.io/badge/large%20size%20(~350h)-preferred-green)
![Possible for "Large" GSoC 2022 project](https://img.shields.io/badge/large%20size%20(~350h)-possible-yellow)
![Not recommended for "Large" GSoC 2022 project](https://img.shields.io/badge/large%20size%20(~350h)-not%20recommended-red)

Each idea should pick one badge for medium and one for large.