### PR TITLE
chore: Split MD and HTML content in api tools

### DIFF
--- a/_includes/api-tools.html
+++ b/_includes/api-tools.html
@@ -1,0 +1,21 @@
+<section id="tool-list">
+<div>
+ {% for tool in site.data.api-tools %}
+    <div>
+        <div style="background: #f2f2f2;width: 80%">
+          <h4><a href="{{tool.link}}">{{ tool.name }}</a> from {{tool.from}}</h4>
+        </div>
+        <div style="background: #cccccc;width: 80%">
+            <img src="{{tool.license}}" alt="License"> |
+            <img src="{{tool.platforms}}" alt="Platform"> |
+            <img src="{{tool.posture}}" alt="API Posture"> |
+            <img src="{{tool.runtime}}" alt="API Runtime"> |
+            <img src="{{tool.testing}}" alt="API Testing">
+            {{tool.notes}}
+        </div>
+    </div>
+    <div style="height:18px;"></div>
+{% endfor %}
+</div>
+<br/><br/>
+</section>

--- a/pages/api-security-tools.md
+++ b/pages/api-security-tools.md
@@ -3,11 +3,13 @@
 title: API Security Tools
 layout: col-sidebar
 author: Matt Tesauro
-contributors:
+contributors: kingthorin
 tags: api, tools, oss
 permalink: /api_security_tools
 
 ---
+
+{% include writers.html %}
 
 APIs are becoming an increasingly large portion of the software that powers the Internet including mobile applications, single-page applications (SPAs) and cloud infrastructure. While APIs share much of the same security controls and software security issues with traditional web applications, they are different enough to make a distinction between 'normal' AppSec tools and ones that were built with APIs in mind.  This page was created to list tools known to support APIs natively and by design.
 
@@ -28,29 +30,8 @@ The goal is to provide as comprehensive a list of API tools as possible using th
 
 ## API Tools List
 
-<section id="tool-list">
-<div>
- {% for tool in site.data.api-tools %}
-    <div>
-        <div style="background: #f2f2f2;width: 80%">
-          <h4><a href="{{tool.link}}">{{ tool.name }}</a> from {{tool.from}}</h4>
-        </div>
-        <div style="background: #cccccc;width: 80%">
-            <img src="{{tool.license}}" alt="License"> |
-            <img src="{{tool.platforms}}" alt="Platform"> |
-            <img src="{{tool.posture}}" alt="API Posture"> |
-            <img src="{{tool.runtime}}" alt="API Runtime"> |
-            <img src="{{tool.testing}}" alt="API Testing">
-            {{tool.notes}}
-        </div>
-    </div>
-    <div style="height:18px;"></div>
-{% endfor %}
-</div>
-<br/><br/>
-</section>
+{% include api-tools.html %}
 
 #### Adding Tools
 
 To add items, please add a stanza to the yaml file [here](https://github.com/OWASP/www-community/blob/master/_data/api-tools.yml) or email me at matt.tesauro AT owasp.org
-<div style="height:18px;"></div>


### PR DESCRIPTION
Include the writers include so that author/contributor info is displayed. Split the HTML content into an include and use it within the MD "page".

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>