### PR TITLE
tools: remove DefenseCode and add Mend

### DIFF
--- a/_data/tools.json
+++ b/_data/tools.json
@@ -1296,15 +1296,6 @@
       "type": "SAST"
    },
    {
-      "title": "Thunderscan SAST",
-      "url": "https://www.defensecode.com/thunderscan-sast/",
-      "owner": "DefenseCode",
-      "license": "Commercial",
-      "platforms": null,
-      "note": "Static security analysis for 27+ languages.",
-      "type": "SAST"
-   },
-   {
       "title": "Veracode Static Analysis",
       "url": "https://www.veracode.com/products/binary-static-analysis-sast",
       "owner": "Veracode",

--- a/_data/tools.json
+++ b/_data/tools.json
@@ -1771,5 +1771,5 @@
       "platforms": null,
       "note": "Static security analysis for 27+ languages.",
       "type": "SAST"
-   },
+   }
 ]

--- a/_data/tools.json
+++ b/_data/tools.json
@@ -1762,5 +1762,14 @@
       "platforms": "SaaS",
       "note": "Mobile application security testing tool for compiled Android apps with support of CI/CD integration",
       "type": "SAST"
-   }
+   },
+   {
+      "title": "Mend SAST",
+      "url": "https://www.mend.io/sast/",
+      "owner": "Mend",
+      "license": "Commercial",
+      "platforms": null,
+      "note": "Static security analysis for 27+ languages.",
+      "type": "SAST"
+   },
 ]


### PR DESCRIPTION
Removing DefenseCode Thunderscan because DefenseCode have merge with WhiteSource (also WhiteSource have recently renamed to Mend).

See

- https://www.defensecode.com/ 
- https://www.mend.io/product-info/news/whitesource-announces-remediation-centric-entry-into-the-sast-market/

Update: I have added Mend