### PR TITLE
tools: remove RIPS

### DIFF
--- a/_data/tools.json
+++ b/_data/tools.json
@@ -1251,15 +1251,6 @@
       "type": "SAST"
    },
    {
-      "title": "RIPS Code Analysis",
-      "url": "https://www.ripstech.com/",
-      "owner": "RIPS Technologies - Acquired by SonarSource",
-      "license": "Commercial",
-      "platforms": null,
-      "note": "Static security analyzer for Java and PHP.",
-      "type": "SAST"
-   },
-   {
       "title": "SecureAssist",
       "url": "https://community.synopsys.com/s/article/SecureAssist-Overview",
       "owner": "Synopsys",


### PR DESCRIPTION
as the comment states RIPS has been acquired by SonarSource, the product no longer exists alone and SonarSource products are already listed.