### PR TITLE
HuskyCI: fix url

### DIFF
--- a/_data/tools.json
+++ b/_data/tools.json
@@ -883,7 +883,7 @@
    },
    {
       "title": "HuskyCI",
-      "url": "https://huskyci.opensource.globo.com/",
+      "url": "https://github.com/globocom/huskyCI",
       "owner": null,
       "license": "Open Source or Free",
       "platforms": null,


### PR DESCRIPTION
website domain is dead, replace with the source repository