### PR TITLE
Component pages: SourceClear --> Veracode

### DIFF
--- a/pages/Component_Analysis.md
+++ b/pages/Component_Analysis.md
@@ -318,7 +318,7 @@ and legal teams an opportunity to create solutions for healthy open source usage
 | [Renovate] | Key Location | Open Source | SaaS |
 | [Retire.js] | RetireJS Project | Open Source | Cross Platform |
 | [Snyk] | Snyk | Commercial / Freemium | SaaS |
-| [SourceClear] | Veracode | Commercial | Cross Platform / SaaS |
+| [Veracode SCA] | Veracode | Commercial | Cross Platform / SaaS |
 | [VulnDB] | Risk Based Security | Commercial	| SaaS |
 | [Vigiles] | Timesys | Commercial / Freemium | SaaS |
 | [Vigilant Ops InSight] | Vigilant Ops | Commercial | Cross Platform / SaaS |
@@ -356,7 +356,7 @@ and legal teams an opportunity to create solutions for healthy open source usage
 [Prisma Cloud]: https://www.paloaltonetworks.com/prisma/cloud
 [Renovate]: https://renovatebot.com/
 [Snyk]: https://snyk.io/
-[SourceClear]: https://www.sourceclear.com/
+[Veracode SCA]: https://www.veracode.com/products/software-composition-analysis
 [Nexus IQ]: https://www.sonatype.com/
 [Open Source Lifecycle Management]: https://www.whitesourcesoftware.com/
 [Retire.js]: https://retirejs.github.io/retire.js/


### PR DESCRIPTION
SourceClear brand is retired; offering now called Veracode SCA. See offering page at https://www.veracode.com/products/software-composition-analysis