### PR TITLE
Update Netsparker to Invicti per 2022 rebrand

### DIFF
--- a/_data/tools.json
+++ b/_data/tools.json
@@ -441,9 +441,9 @@
       "type": "DAST"
    },
    {
-      "title": "Netsparker",
-      "url": "https://www.netsparker.com/",
-      "owner": "Netsparker",
+      "title": "Invicti, formerly Netsparker",
+      "url": "https://www.invicti.com/",
+      "owner": "Invicti",
       "license": "Commercial",
       "platforms": "Windows",
       "note": null,


### PR DESCRIPTION
Netsparker has rebranded to Invicti and has a new domain.