### PR TITLE
Allow long domain names

### DIFF
--- a/pages/OWASP_Validation_Regex_Repository.md
+++ b/pages/OWASP_Validation_Regex_Repository.md
@@ -40,7 +40,7 @@ Please carefully test the regex in your regex engine.
 
   <regex>
     <name>e-mail</name>
-    <pattern><![CDATA[^[a-zA-Z0-9_+&*-]+(?:\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,15}$]]></pattern>
+    <pattern><![CDATA[^[a-zA-Z0-9_+&*-]+(?:\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$]]></pattern>
     <description>A valid e-mail address</description>
   </regex>
 


### PR DESCRIPTION
Hi all,

According to [List of Internet top-level domains](https://en.wikipedia.org/wiki/List_of_Internet_top-level_domains) there are few domains that doesn't fulfil regex like `travelersinsurance` or `northwesternmutual`. 
This one updates Email Validation Regex to cover those long domain names.

I've removed upper limit to have it working in case new long TLDs will be registered. Another option would be to put upper limit to 18

Thank you