### PR TITLE
Remove Abbey Scan

### DIFF
--- a/_data/tools.json
+++ b/_data/tools.json
@@ -72,15 +72,6 @@
       "type": "DAST"
    },
    {
-      "title": "Abbey Scan",
-      "url": "https://misterscanner.com/",
-      "owner": "MisterScanner",
-      "license": "Commercial",
-      "platforms": "SaaS",
-      "note": null,
-      "type": "DAST"
-   },
-   {
       "title": "Acunetix",
       "url": "https://www.acunetix.com/",
       "owner": "Acunetix",


### PR DESCRIPTION
Closes #686 

Refer to: https://github.com/OWASP/www-community/pull/326, Abbey (aka Mister Scan) should NOT be re-added.