### PR TITLE
Add VulnSign to List of Vulnerability Scanning Tools

### DIFF
--- a/_data/tools.json
+++ b/_data/tools.json
@@ -657,6 +657,15 @@
       "type": "DAST"
    },
    {
+      "title": "VulnSign",
+      "url": "https://vulnsign.com",
+      "owner": "VulnSign",
+      "license": "Commercial",
+      "platforms": "SaaS or On-Premises",
+      "note": null,
+      "type": "DAST"
+   },
+   {
       "title": "Wapiti",
       "url": "https://wapiti.sourceforge.io/",
       "owner": "Informática Gesfor",


### PR DESCRIPTION
VulnSign is missing in the List of Vulnerability Scanning Tools
https://owasp.org/www-community/Vulnerability_Scanning_Tools

This PR adds the corresponding information.