### PR TITLE
Remove reference to MD5 in Unrestricted File Upload article

### DIFF
--- a/pages/vulnerabilities/Unrestricted_File_Upload.md
+++ b/pages/vulnerabilities/Unrestricted_File_Upload.md
@@ -369,7 +369,7 @@ And some special recommendations for the developers and webmasters:
     name of a file plus its extension should be less than 255 characters
     (without any directory) in an NTFS partition.
   - It is recommended to use an algorithm to determine the filenames.
-    For instance, a filename can be a Keccak hash of the name of file plus
+    For instance, a filename can be a hash of the name of file plus
     the date of the day.
   - Uploaded directory should not have any "execute" permission and all
     the script handlers should be removed from these directories.

--- a/pages/vulnerabilities/Unrestricted_File_Upload.md
+++ b/pages/vulnerabilities/Unrestricted_File_Upload.md
@@ -369,7 +369,7 @@ And some special recommendations for the developers and webmasters:
     name of a file plus its extension should be less than 255 characters
     (without any directory) in an NTFS partition.
   - It is recommended to use an algorithm to determine the filenames.
-    For instance, a filename can be a MD5 hash of the name of file plus
+    For instance, a filename can be a Keccak hash of the name of file plus
     the date of the day.
   - Uploaded directory should not have any "execute" permission and all
     the script handlers should be removed from these directories.


### PR DESCRIPTION
It's a good idea to write another example of hashing algorithm (Keccak, other ideas) due to the large number of ways to crack MD5