### PR TITLE
Update HTTP_Response_Splitting.md

### DIFF
--- a/pages/attacks/HTTP_Response_Splitting.md
+++ b/pages/attacks/HTTP_Response_Splitting.md
@@ -72,7 +72,7 @@ However, because the value of the cookie is formed of unvalidated user
 input, the response will only maintain this form if the value submitted
 for AUTHOR_PARAM does not contain any CR and LF characters. If an
 attacker submits a malicious string, such as "Wiley
-Hacker\\r\\nContent-Length:45\\r\\n\\r\\n...", then the HTTP response
+Hacker\\r\\nContent-Length:999\\r\\n\\r\\n...", then the HTTP response
 would be split into an imposter response followed by the original
 response, which is now ignored:
 


### PR DESCRIPTION
Changed injected content length header from 45 to 999 to match example request below:

```
    HTTP/1.1 200 OK
    ...
    Set-Cookie: author=Wiley Hacker
    Content-Length: 999

    <html>malicious content...</html> (to 999th character in this example)
    Original content starting with character 1000, which is now ignored by the web browser...
```