### PR TITLE
Update Regular_expression_Denial_of_Service_-_ReDoS.md

### DIFF
--- a/pages/attacks/Regular_expression_Denial_of_Service_-_ReDoS.md
+++ b/pages/attacks/Regular_expression_Denial_of_Service_-_ReDoS.md
@@ -123,15 +123,6 @@ Input:
 
 `aaaaaaaaaaaaaaaaaaaaaaaa!`
 
-2. [OWASP Validation Regex Repository](https://wiki.owasp.org/index.php/OWASP_Validation_Regex_Repository), Java
-Classname - see bold part, which is an **Evil Regex**
-
-`^`**`(([a-z])+.)+`**`[A-Z]([a-z])+$`
-
-Input:
-
-`aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!`
-
 ### Web application attack
 
 - Open a JavaScript


### PR DESCRIPTION
The regex used uses a dot instead of a dot character and was therefore incorrect in the first place. The regexps linked to are too limited as well (class names can contain digits, inner classes can contain a dot or a hash symbol etc. etc.). Unfortunately the Wikipedia it points to cannot be altered by new accounts, so any information in it could remain incorrect forever. So this example has no use and should get rid of. A new example should probably be provided, but I don't know one from the top of my head.