### PR TITLE
edited CSV_Injection.md sanitization recommendations

### DIFF
--- a/pages/attacks/CSV_Injection.md
+++ b/pages/attacks/CSV_Injection.md
@@ -3,7 +3,7 @@
 layout: col-sidebar
 title: CSV Injection
 author: Timo Goosen, Albinowax
-contributors: kingthorin
+contributors: kingthorin, budgy11
 permalink: /attacks/CSV_Injection
 tags: attack, vulnerability, CSV Injection
 
@@ -37,7 +37,6 @@ begin with any of the following characters:
 Keep in mind that it is not sufficient to make sure that the untrusted user input does not start with these characters. You also need to take care of the field separator (e.g., '`,`', or '`;`') and quotes (e.g., `'`, or `"`), as attackers could use this to start a new cell and then have the dangerous character in the middle of the user input, but at the beginning of a cell.
 
 Alternatively, apply the following sanitization to each field of the CSV, so that their content will be read as text by the spreadsheet editor:
-* Wrap each cell field in double quotes
 * Prepend each cell field with a single quote
 * Escape every double quote using an additional double quote
 


### PR DESCRIPTION
I believe the sanitization recommendation to wrap each cell in double quotes is ineffective in Excel and shouldn't be recommended. If recommended potential issues with Excel should be noted.

![CSV Injection with double quotes](https://user-images.githubusercontent.com/38967167/231001112-bfaff903-9d6f-4c3a-b6d1-42dbe6318ef7.png)
