### PR TITLE
Remove duplicate VisualCodeGrepper row

### DIFF
--- a/_data/tools.json
+++ b/_data/tools.json
@@ -1494,15 +1494,6 @@
       "type": "SAST"
    },
    {
-      "title": "VisualCodeGrepper",
-      "url": "https://sourceforge.net/projects/visualcodegrepp/",
-      "owner": null,
-      "license": "Open Source or Free",
-      "platforms": "Windows",
-      "note": "C/C++, C\\#, VB, PHP, Java, PL/SQL",
-      "type": "SAST"
-   },
-   {
       "title": "Fortify",
       "url": "https://www.microfocus.com/en-us/products/static-code-analysis-sast/overview",
       "owner": "Micro Focus",


### PR DESCRIPTION
`VisualCodeGrepper` is duplicated over two row on the [Source Code Analysis Tools](https://owasp.org/www-community/Source_Code_Analysis_Tools) web page as per the screenshot below:

![image](https://github.com/OWASP/www-community/assets/136826/11b68b4e-8b85-4f9b-b576-9c1630c2e116)

This duplication is highlighted in the [GitHub Code Search](url) reproduced below

![image](https://github.com/OWASP/www-community/assets/136826/647ae24a-f0f6-4f87-b6a2-083022470394)

This Pull Request removes the brief first row as the second row contains more information.
