### PR TITLE
Add OWASP pytm to Risk Rating Methodology

### DIFF
--- a/pages/OWASP_Risk_Rating_Methodology.md
+++ b/pages/OWASP_Risk_Rating_Methodology.md
@@ -24,7 +24,8 @@ Alternatively you may with the review information about Threat Modeling, as that
 
 - <https://owasp.org/www-community/Threat_Modeling>
 - <https://owasp.org/www-community/Application_Threat_Modeling>
-- [OWASP Threat Dragon](https://owasp.org/www-project-threat-dragon/)
+- [OWASP pytm](https://owasp.org/www-project-pytm/) Pythonic framework for threat modeling
+- [OWASP Threat Dragon](https://owasp.org/www-project-threat-dragon/) threat modeling tool
 
 Lastly you might want to refer to the [references](#references) below.
 


### PR DESCRIPTION
There are two OWASP tools for threat modeling, pytm and Threat Dragon, both equally good and different in their approach
This pull request adds a link to pytm alongside the existing link to Threat Dragon

@izar I am sure you would agree