### PR TITLE
Remove invalid link on SSI Injection page

### DIFF
--- a/pages/attacks/Server-Side_Includes_(SSI)_Injection.md
+++ b/pages/attacks/Server-Side_Includes_(SSI)_Injection.md
@@ -152,6 +152,5 @@ and executes arbitrary code.
 
 ## References
 
-- [SSI Examples](http://www.comptechdoc.org/independent/web/cgi/ssimanual/ssiexamples.html)
 - [CGI and SSI Syntax and Examples](http://httpd.apache.org/docs/current/howto/ssi.html#basic)
 - [Injection Flaws](https://owasp.org/www-community/Injection_Flaws)


### PR DESCRIPTION
The old link is outdated.
This is a quick fix related to #292 .