### PR TITLE
Unrestricted File Upload - fix regular expression for validate file name

### DIFF
--- a/pages/vulnerabilities/Unrestricted_File_Upload.md
+++ b/pages/vulnerabilities/Unrestricted_File_Upload.md
@@ -364,7 +364,7 @@ And some special recommendations for the developers and webmasters:
     characters and only 1 dot as an input for the file name and the
     extension; in which the file name and also the extension should not
     be empty at all (regular expression:
-    \[a-zA-Z0-9\]{1,200}\\.\[a-zA-Z0-9\]{1,10}).
+    `^\[a-zA-Z0-9\]{1,200}\\.\[a-zA-Z0-9\]{1,10}$`).
   - Limit the filename length. For instance, the maximum length of the
     name of a file plus its extension should be less than 255 characters
     (without any directory) in an NTFS partition.


### PR DESCRIPTION
The inserted regex `[a-zA-Z0-9]{1,200}\.[a-zA-Z0-9]{1,10}` does not allow validation of the double extension. 
![image](https://github.com/OWASP/www-community/assets/39196215/aca59401-5e5e-4c3b-a466-f5e5fe2bcd2e)
The name must be enforced to be valid if the entire string matches:
![image](https://github.com/OWASP/www-community/assets/39196215/df03bcbf-be2b-4669-9c9d-66ac051e4e7d)
but not:
![image](https://github.com/OWASP/www-community/assets/39196215/bb38ed7e-b006-43db-a2e7-9a02ad225cba)
