### PR TITLE
Update Actions to Node 16

### DIFF
--- a/.github/workflows/validate-tools-json.yml
+++ b/.github/workflows/validate-tools-json.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{github.event.pull_request.head.ref}}
         repository: ${{github.event.pull_request.head.repo.full_name}}
     - name: Setup Node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 13.x
     - name: Install dependencies


### PR DESCRIPTION
Node 12 has been deprecated in GitHub Actions.  Use latest versions of Actions.

Refer to https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/