### PR TITLE
No leading whitespace in tools title

### DIFF
--- a/.github/workflows/validate-tools-json.yml
+++ b/.github/workflows/validate-tools-json.yml
@@ -4,6 +4,7 @@ on:
   pull_request_target:
     paths:
     - '_data/tools.json'
+    - 'tools_schema.json'
 
 permissions:
   contents: read

--- a/_data/tools.json
+++ b/_data/tools.json
@@ -18,7 +18,7 @@
       "type": "DAST"
    },
  {
-      "title": " Threatspy",
+      "title": "Threatspy",
       "url": "https://www.secureblink.com/threatspy",
       "owner": "Secure Blink",
       "license": "Commercial or Free",
@@ -27,7 +27,7 @@
       "type": "DAST"
    },
      {
-      "title": " Akto",
+      "title": "Akto",
       "url": "https://www.akto.io/",
       "owner": "Akto",
       "license": "Commercial",
@@ -1845,7 +1845,7 @@
       "type": "DAST"
    },
    {
-      "title": " SecOps Solution",
+      "title": "SecOps Solution",
       "url": "https://secopsolution.com",
       "owner": "SecOps Solution",
       "license": "Commercial or Free",

--- a/tools_schema.json
+++ b/tools_schema.json
@@ -23,7 +23,8 @@
 			"title": {
 				"$id": "#root/items/title",
 				"title": "Title",
-				"type": "string"
+				"type": "string",
+				"pattern": "^\\S.*"
 			},
 			"url": {
 				"$id": "#root/items/url",


### PR DESCRIPTION
The tools are sorted by title when constructing the HTML table. Leading whitespace causes an unintended sort order. Add a pattern for the title property to enforce no leading whitespace.