### PR TITLE
Fix broken link in Improper_Error_Handling page

### DIFF
--- a/pages/Improper_Error_Handling.md
+++ b/pages/Improper_Error_Handling.md
@@ -61,7 +61,7 @@ are susceptible to error handling problems.
 
 ## Examples and References
 
-- [OWASP Testing Guide](https://owasp.org/www-project-web-security-testing-guide/)
+- [OWASP Testing Guide](/www-project-web-security-testing-guide/)
 
 ## How to Determine If You Are Vulnerable
 

--- a/pages/Improper_Error_Handling.md
+++ b/pages/Improper_Error_Handling.md
@@ -61,7 +61,7 @@ are susceptible to error handling problems.
 
 ## Examples and References
 
-- [OWASP Testing Guide]/www-project-web-security-testing-guide)
+- [OWASP Testing Guide](https://owasp.org/www-project-web-security-testing-guide/)
 
 ## How to Determine If You Are Vulnerable
 


### PR DESCRIPTION
This is how the link looked before the fix:
![image](https://github.com/OWASP/www-community/assets/87483058/9cb59cd8-0cc9-4f62-8beb-572b167ade2f)
