### PR TITLE
Important Reverse Tabnabbing update - automatically fixed

### DIFF
--- a/pages/attacks/Reverse_Tabnabbing.md
+++ b/pages/attacks/Reverse_Tabnabbing.md
@@ -12,6 +12,20 @@ auto-migrated: 1
 
 {% include writers.html %}
 
+## Update 2023 - this is fixed in modern, evergreen, browsers 
+
+Links that use `target="_blank"`now have implicite `rel="noopener"` in 
+modern browsers, so this vulnerability isn't as widespread and critical 
+as before.This implicite rule is also a part of the 
+[HTML standard](https://github.com/whatwg/html/issues/4078).
+According to Caniuse.com evergreen browsers support implicit `rel="noopener` 
+from about 2018, but there are still some browsers out there that doesn't support
+it, so please consider your userbase when/if deciding to
+drop `rel="noopener"`.
+
+Using `rel="noreferrer"` implies also `rel="noopener`, so if you have 
+chosen to use `rel="noreferrer`, the use of `rel="noopener` isn't required.
+
 ## Description
 
 Reverse tabnabbing is an attack where a page linked from the target page
@@ -106,10 +120,17 @@ object reference.
 
 ## Prevention
 
-Prevention information are documented into the [HTML5 Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/HTML5_Security_Cheat_Sheet.html#tabnabbing).
+Please check the first heading on this page, Update 2023, as this is now automatically prevented in all modern, evergreen, browsers. 
+Check prevention information documented in the [HTML5 Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/HTML5_Security_Cheat_Sheet.html#tabnabbing).
 
 ## References
 
+- [WHATWG HTML - Windows opened via <a target=_blank> should not have an opener by default](https://github.com/whatwg/html/issues/4078)
+- [Caniuse implicit rel="noopener" when using target="_blank"](https://caniuse.com/mdn-html_elements_a_implicit_noopener)
+- [Chrome Platform Status - Feature: Anchor target=_blank implies rel=noopener by default](https://chromestatus.com/feature/6140064063029248)
+- [Chromium - Issue 898942: Anchor target=_blank should imply rel=noopener](https://bugs.chromium.org/p/chromium/issues/detail?id=898942)
+- [Mozilla - Make target=_blank on a/area elements imply rel=noopener by default](https://bugzilla.mozilla.org/show_bug.cgi?id=1522083)
+- [WebKit Bugzilla - Bug 190481: Experiment: target=_blank on anchors should imply rel=noopener](https://bugs.webkit.org/show_bug.cgi?id=190481)
 - [The `target="_blank"` vulnerability by example](https://dev.to/ben/the-targetblank-vulnerability-by-example)
 - [About `rel=noopener` attribute values](https://mathiasbynens.github.io/rel-noopener/)
 - [Target="_blank" —  the most underestimated vulnerability ever](https://medium.com/@jitbit/target-blank-the-most-underestimated-vulnerability-ever-96e328301f4c)

--- a/pages/attacks/Reverse_Tabnabbing.md
+++ b/pages/attacks/Reverse_Tabnabbing.md
@@ -14,7 +14,7 @@ auto-migrated: 1
 
 ## Update 2023 - this is fixed in modern, evergreen, browsers 
 
-Links that use `target="_blank"`now have implicite `rel="noopener"` in 
+Links that use `target="_blank"`  now have implicit `rel="noopener"` in 
 modern browsers, so this vulnerability isn't as widespread and critical 
 as before.This implicite rule is also a part of the 
 [HTML standard](https://github.com/whatwg/html/issues/4078).

--- a/pages/attacks/Reverse_Tabnabbing.md
+++ b/pages/attacks/Reverse_Tabnabbing.md
@@ -16,7 +16,7 @@ auto-migrated: 1
 
 Links that use `target="_blank"`  now have implicit `rel="noopener"` in 
 modern browsers, so this vulnerability isn't as widespread and critical 
-as before.This implicite rule is also a part of the 
+as before. This implicit rule is also a part of the 
 [HTML standard](https://github.com/whatwg/html/issues/4078).
 According to Caniuse.com evergreen browsers support implicit `rel="noopener"` 
 from about 2018, but there are still some browsers out there that doesn't support

--- a/pages/attacks/Reverse_Tabnabbing.md
+++ b/pages/attacks/Reverse_Tabnabbing.md
@@ -24,7 +24,7 @@ it, so please consider your userbase when/if deciding to
 drop `rel="noopener"`.
 
 Using `rel="noreferrer"` implies also `rel="noopener"`, so if you have 
-chosen to use `rel="noreferrer`, the use of `rel="noopener` isn't required.
+chosen to use `rel="noreferrer"`, the use of `rel="noopener"` isn't required.
 
 ## Description
 

--- a/pages/attacks/Reverse_Tabnabbing.md
+++ b/pages/attacks/Reverse_Tabnabbing.md
@@ -23,7 +23,7 @@ from about 2018, but there are still some browsers out there that doesn't suppor
 it, so please consider your userbase when/if deciding to
 drop `rel="noopener"`.
 
-Using `rel="noreferrer"` implies also `rel="noopener`, so if you have 
+Using `rel="noreferrer"` implies also `rel="noopener"`, so if you have 
 chosen to use `rel="noreferrer`, the use of `rel="noopener` isn't required.
 
 ## Description

--- a/pages/attacks/Reverse_Tabnabbing.md
+++ b/pages/attacks/Reverse_Tabnabbing.md
@@ -18,7 +18,7 @@ Links that use `target="_blank"`now have implicite `rel="noopener"` in
 modern browsers, so this vulnerability isn't as widespread and critical 
 as before.This implicite rule is also a part of the 
 [HTML standard](https://github.com/whatwg/html/issues/4078).
-According to Caniuse.com evergreen browsers support implicit `rel="noopener` 
+According to Caniuse.com evergreen browsers support implicit `rel="noopener"` 
 from about 2018, but there are still some browsers out there that doesn't support
 it, so please consider your userbase when/if deciding to
 drop `rel="noopener"`.


### PR DESCRIPTION
Latest evergreen browsers fix this under the hood, respecting the update in the HTML spec where `target="_blank"` implies `rel="noopener"` implicitly.

- Added a heading with the update info at the start of the page, so that it's clear this may be automatically remediated by the browser.
- Added sentence about this also in the Prevention section.
- Added relevant updated information at the top of the References list.