### PR TITLE
Update Cache_Poisoning.md to correct site link

### DIFF
--- a/pages/attacks/Cache_Poisoning.md
+++ b/pages/attacks/Cache_Poisoning.md
@@ -137,4 +137,4 @@ The request examples used are from the Amit Klein paper referenced below, which 
 needs of the article.
 
 More information can be found in this document, which focuses on these
-kinds of attacks [by Amit Klein, Director of Security and Research](http://packetstormsecurity.org/papers/general/whitepaper_httpresponse.pdf)
+kinds of attacks [by Amit Klein, Director of Security and Research](https://packetstormsecurity.com/files/32815/Divide-and-Conquer-HTTP-Response-Splitting-Whitepaper.html)


### PR DESCRIPTION
The HTTP Response white paper has the incorrect link. It's currently linking out to musician's site as the site has changed from packetstormsecurity.org to packetstormsecurity.com.