### PR TITLE
Replace openapi.security by graphql.security in "API Security Tools" list

### DIFF
--- a/_data/api-tools.yml
+++ b/_data/api-tools.yml
@@ -161,7 +161,7 @@
   testing: "https://img.shields.io/badge/API_Testing-Yes-brightgreen.svg"
   notes: "Freemium, online versions of the tool are also available: <br/>
          <ul><li><a href='https://openapi.security'>OpenAPI.Security</a></li>
-         <li><a href='https://openapi.security'>GraphQL.Security</a></li></ul>"
+         <li><a href='https://graphql.security'>GraphQL.Security</a></li></ul>"
 - name: "ffuf"
   link: "https://github.com/ffuf/ffuf"
   from: "ffuf"


### PR DESCRIPTION
The links for GraphQL.security sounds the bad one.