### PR TITLE
docs: format code examples

### DIFF
--- a/pages/attacks/Buffer_overflow_attack.md
+++ b/pages/attacks/Buffer_overflow_attack.md
@@ -35,12 +35,11 @@ architecture.
 
 ```C
 #include <stdio.h>
-int main(int argc, char **argv)
-{
-char buf[8]; // buffer for eight characters
-gets(buf); // read from stdio (sensitive function!)
-printf("%s\n", buf); // print out data stored in buf
-return 0; // 0 as return value
+int main(int argc, char **argv) {
+  char buf[8];         // buffer for eight characters
+  gets(buf);           // read from stdio (sensitive function!)
+  printf("%s\n", buf); // print out data stored in buf
+  return 0;            // 0 as return value
 }
 ```
 
@@ -95,21 +94,19 @@ data stored in this memory area.
 #include <stdio.h>
 #include <string.h>
 
-void doit(void)
-{
-        char buf[8];
+void doit(void) {
+  char buf[8];
 
-        gets(buf);
-          printf("%s\n", buf);
+  gets(buf);
+  printf("%s\n", buf);
 }
 
-int main(void)
-{
-        printf("So... The End...\n");
-        doit();
-        printf("or... maybe not?\n");
+int main(void) {
+  printf("So... The End...\n");
+  doit();
+  printf("or... maybe not?\n");
 
-        return 0;
+  return 0;
 }
 ```
 


### PR DESCRIPTION
Format C code examples using `clang-format`. This improves readability and comprehension.

For more on clang-format, see <https://clang.llvm.org/docs/ClangFormat.html>
