### PR TITLE
docs: update deprecated information on GSoC Student Guidelines

### DIFF
--- a/pages/initiatives/gsoc/gsoc2024.md
+++ b/pages/initiatives/gsoc/gsoc2024.md
@@ -53,7 +53,7 @@ steps and some tips on getting started:
 
 1. Think of a good idea – For reference from last year see [GSoc {{page.year | minus:1}} Ideas](gsoc{{page.year | minus:1}}ideas).
 2. Do some research yourself based on the idea, write up a proposal draft
-3. Post it to the OWASP mailing list at [https://groups.google.com/d/forum/owasp-gsoc](https://groups.google.com/forum/#!forum/owasp-gsoc) for initial discussions with OWASP mentors.
+3. Post it to the #gsoc channel at [OWASP Slack](https://owasp.org/slack/invite) for initial discussions with OWASP mentors.
 4. Based on feedback, write a full proposal – See template below: [GSoC SAT](gsoc_sat)
 5. Submit your proposal to Google
 
@@ -64,7 +64,7 @@ quality results and be engaging with their mentors and community. You don't have
 meant to facilitate joining OWASP and other Open Source communities. However, experience in coding and applications are welcome.
 
 You should start familiarizing yourself with the projects that you plan on working on before the start date. OWASP Project Mentors are available
-on the mailing list [https://groups.google.com/d/forum/owasp-gsoc](https://groups.google.com/d/forum/owasp-gsoc) for help.
+on #gsoc channel at the [OWASP Slack](https://owasp.org/slack/invite) for help.
 
 ### General Instructions
 
@@ -74,7 +74,7 @@ and the
 
 ### Getting in touch
 
-- Google Group: OWASP Organization Administrators and Mentors are available at [https://groups.google.com/d/forum/owasp-gsoc](https://groups.google.com/d/forum/owasp-gsoc) ready to answer any questions and discuss any idea.
+- Slack: OWASP Organization Administrators and Mentors are available at [OWASP Slack](https://owasp.org/slack/invite) ready to answer any questions and discuss any idea.
 
 ### Recommended Steps
 
@@ -84,14 +84,14 @@ and the
 - Write a first draft [proposal](gsoc_sat) and get someone to review it for you
 - Remember: you must link to work such as commits in your proposal
 - Submit it using Google's web interface ahead of the deadline
-- Submit proof of enrollment well ahead of the deadline
 
 Coming up with an interesting idea is probably the most difficult part of all. It should be something interesting for an OWASP Project, and
 more importantly for you. It also has to be something that you can realistically achieve in the time available to you.
 
-Finding out what the most pressing issues are in the projects you're interested in is a good start. You can optionally join the mailing lists
-for that project: you can make acquaintance with developers and your potential mentor, as well as start learning the codebase. We recommend
-strongly doing that and we will look favorably on applications from students who have started to act like Open Source developers.
+Finding out what the most pressing issues are in the projects you're interested in is a good start. You are encouraged to join the
+[Slack channel](https://owasp.org/slack/invite) for that project: you can make acquaintance with developers and your potential mentor,
+as well as start learning the codebase. We recommend strongly doing that and we will look favorably on applications from students
+who have started to act like Open Source developers.
 
 ### Student Proposal Guidelines
 
@@ -144,7 +144,7 @@ have to work on each.
 The PostgreSQL project has also released a list of [hints](https://wiki.postgresql.org/wiki/GSoC) that you can take a look at.
 
 The KDE project has also released a guide on how to write a
-[kickass proposal](https://teom.wordpress.com/2012/03/01/how-to-write-a-kick-ass-proposal-for-google-summer-of-code/)
+[kickass proposal](https://teom.wordpress.com/2012/03/01/how-to-write-a-kick-ass-proposal-for-google-summer-of-code/).
 
 ## Instructions for mentors
 
@@ -166,14 +166,14 @@ as just a suggestion.
 
 If you wish to help us even more, you can be an OWASP mentor. We will potentially assign a student to you who has never worked on such a large
 project and will need some help. Make sure you're up for the task. When subscribing yourself as a mentor, please make sure that your application
-or module maintainer is aware of that. Ask them to send the Summer of Code OWASP Administrators an email confirming to know you. This is just
-a formality to make sure you are a real person we can trust -- the administrators cannot know all active developers by their Google account
-ID.
+or module maintainer is aware of that. Ask them to send an email to the Summer of Code OWASP Administrators to confirm that they are aware of you
+becoming a mentor. This is just a formality to make sure you are a real person we can trust -- the administrators cannot know all active developers
+by their Google account ID.
 
 If you would like to get an idea of what is involved in being a good mentor, be sure to read the
 [mentoring guide](https://google.github.io/gsocguides/mentor/).
 
-You will be subscribed to a mailing list to discuss ideas. We will also require you to read the proposals as they come in and you will be
+You will be required to read the proposals as they come in and you will be
 allowed to vote on the proposals, according to rules we will publish later.
 
 Finally, know that we will never assign you to a project you do not want to work on. We will not assign you more projects than you can/want to
@@ -186,7 +186,7 @@ To subscribe as mentor, you need to complete a few easy steps.
 - Contact the OWASP GSoC administrators to let them know which project you want to mentor for
 - Log in to [Google Summer of Code Program Site](https://summerofcode.withgoogle.com/)
 - Apply as a mentor for OWASP
-- Subscribe to [https://groups.google.com/d/forum/owasp-gsoc](https://groups.google.com/d/forum/owasp-gsoc)
+- Follow the #gsoc channel on [Slack](https://owasp.org/slack/invite).
 
 ## Instructions for OWASP Project Leaders
 

--- a/pages/initiatives/gsoc/gsoc2024.md
+++ b/pages/initiatives/gsoc/gsoc2024.md
@@ -38,7 +38,7 @@ This program is done completely online. Students and mentors from more than 100 
 All participants should take a look at the [Google Summer of Code Program Site](https://summerofcode.withgoogle.com/) every
 now and then to be informed about updates and advice. It is also important to read the 
 [Summer of Code FAQ](https://developers.google.com/open-source/gsoc/faq), as it contains useful information. All participants will need a Google account in order to join the program. You'll save some time if you create one now. Please
-review the [GSOC TimeLine](https://summerofcode.withgoogle.com/how-it-works/#timeline).
+review the [GSOC TimeLine](https://developers.google.com/open-source/gsoc/timeline).
 
 ### Programming Language
 
@@ -53,7 +53,7 @@ steps and some tips on getting started:
 
 1. Think of a good idea – For reference from last year see [GSoc {{page.year | minus:1}} Ideas](gsoc{{page.year | minus:1}}ideas).
 2. Do some research yourself based on the idea, write up a proposal draft
-3. Post it to the mailing list at [https://groups.google.com/d/forum/owasp-gsoc](https://groups.google.com/forum/#!forum/owasp-gsoc) for initial discussions with OWASP mentors.
+3. Post it to the OWASP mailing list at [https://groups.google.com/d/forum/owasp-gsoc](https://groups.google.com/forum/#!forum/owasp-gsoc) for initial discussions with OWASP mentors.
 4. Based on feedback, write a full proposal – See template below: [GSoC SAT](gsoc_sat)
 5. Submit your proposal to Google
 


### PR DESCRIPTION
This PR fixes broken links and some deprecated information.

- Delete pointers to deprecated Google Groups page and replace them with the link to the OWASP Slack channel invite page.
- Fix a broken link (GSoC timeline).
- Delete `Submit proof of enrollment` from the list of requirements (no longer required as per GSoC policy change).
