### PR TITLE
Clickjacking.md References cleanup

### DIFF
--- a/pages/attacks/Clickjacking.md
+++ b/pages/attacks/Clickjacking.md
@@ -64,17 +64,10 @@ There are three main ways to prevent clickjacking:
 For more information on Clickjacking defense, please see the the [Clickjacking Defense Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html).
 
 # References
-- [Why am I anxious about Clickjacking?](https://www.linkedin.com/pulse/20141202104842-120953718-why-am-i-anxious-about-clickjacking)
-- A Basic understanding of Clickjacking Attack
-- <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors>
-- Mozilla developer resource on Content-Security-Policy frame-ancestors response header.
-- <https://developer.mozilla.org/en-US/docs/The_X-FRAME-OPTIONS_response_header>
-- Mozilla developer resource on the X-Frame-Options response header.
-- [Busting Frame Busting: A study of clickjacking vulnerabilities on top sites](http://w2spconf.com/2010/papers/p27.pdf)
-- A study by the Stanford Web Security Group outlining problems with deployed frame busting code.
-- [Clickjacking, Sec Theory](http://www.sectheory.com/clickjacking.htm)
-- A paper by Robert Hansen defining the term, its implications against Flash at the time of writing, and a disclosure timeline.
-- <https://www.codemagi.com/blog/post/194>
-- Framebreaking defense for legacy browsers that do not support X-Frame-Option headers.
-- A simple J2EE servlet filter that sends anti-framing headers to the browser.
+- [Why am I anxious about Clickjacking?](https://www.linkedin.com/pulse/20141202104842-120953718-why-am-i-anxious-about-clickjacking) — A Basic understanding of Clickjacking Attack
+- [Content-Security-Policy: frame-ancestors](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors) (Mozilla Developer Network)
+- [X-Frame-Options response header](https://developer.mozilla.org/en-US/docs/The_X-FRAME-OPTIONS_response_header) (Mozilla Developer Network)
+- [Busting Frame Busting: A study of clickjacking vulnerabilities on top sites](http://w2spconf.com/2010/papers/p27.pdf) — A study by the Stanford Web Security Group outlining problems with deployed frame busting code.
+- [Clickjacking, Sec Theory](http://www.sectheory.com/clickjacking.htm) — A paper by Robert Hansen defining the term, its implications against Flash at the time of writing, and a disclosure timeline.
+- [Clickjacking Defense](https://www.codemagi.com/blog/post/194) — Framebreaking defense for legacy browsers that do not support X-Frame-Option headers.
 - [CSP frame-ancestors vs. X-Frame-Options for Clickjacking prevention](https://medium.com/@shaialon/csp-frame-ancestors-vs-x-frame-options-for-clickjacking-prevention-30383a713772)


### PR DESCRIPTION
- Combined list items that referred to the same resource.
- Removed a description of an item that has no URL.

The last two resources are currently not responding, but I have not altered those links. Perhaps they should be changed to Wayback Machine versions.