### PR TITLE
Add CrushFTP to favicons-database.yml

### DIFF
--- a/_data/favicons-database.yml
+++ b/_data/favicons-database.yml
@@ -1308,3 +1308,7 @@
   hash: 57f501d6fee2fdb024795abbdb750ad5
   name: Hak5 Cloud C2
   source: REDC2PORTAL
+- algorithm: MD5
+  hash: 297a81069094d00a052733d3a0537d18
+  name: CrushFTP
+  source: CrushFTP


### PR DESCRIPTION
Added CrushFTP because it is a large common service. Took the favicon hash from the official running demo instance.