### PR TITLE
docs(pages-initiatives): the handler roadmap content

### DIFF
--- a/pages/initiatives/index.md
+++ b/pages/initiatives/index.md
@@ -3,7 +3,7 @@
 layout: col-sidebar
 title: Initiatives
 author:
-contributors:
+contributors: ["Raphael Moreira"]
 tags: initiatives
 permalink: /initiatives/
 
@@ -23,3 +23,15 @@ Information related to OWASP's participation in Google Season of Docs (GSoD) sin
 At various points in OWASP's history the organization has run Code Sprints similar to GSoC in order to give students and the community "real-life" development experience, and as a mechanism by which code projects can grow and be enhanced.
 
 Information related to OWASP Code Sprints can be found [here](code_sprint).
+
+## ISC - The Handler Roadmap
+The [Internet Storm Center (ISC)](https://isc.sans.edu/about.html) was created in 2001 after the successful detection, analysis, 
+and widespread warning of the [Li0n](http://virus.wikidot.com/lion) worm. Today, the ISC provides a free analysis and alert 
+service for thousands of Internet users and organizations, actively collaborating with Internet service providers to combat 
+malicious attackers. The ISC collects millions of intrusion detection records daily, covering over 500,000 IP addresses in 
+more than 50 countries, supported by the [SANS Institute](https://www.sans.org/about/).
+
+The ISC is maintained by volunteers who donate their time to analyze and report security incidents, either through the
+[DShield Sensor](https://isc.sans.edu/howto.html) or through their elevated knowledge, as a [Handler](https://isc.sans.edu/handler_list.html).
+
+Now you can follow the path to become one of them. So [let's go!](isc_handler_roadmap/index.md)

--- a/pages/initiatives/isc_handler_roadmap/acts/act_1.md
+++ b/pages/initiatives/isc_handler_roadmap/acts/act_1.md
@@ -1,0 +1,103 @@
+---
+
+layout: col-sidebar
+title: "Act I - Observing Behind the Curtain"
+author: "Raphael Moreira"
+contributors: 
+permalink: /initiatives/isc_handler_roadmap/acts
+tags: ["cybersecurity", "protocol", "http", "network", "response header", "xss", "csrf", "clickjacking", hsts", "csp", "ssl"]
+
+---
+
+{% include writers.html %}
+
+🇺🇸 | [🇧🇷](act_1.pt-BR.md)
+
+# Act I - Observing Behind the Curtain
+Whenever a website is accessed, a series of processes occurs behind the scenes through the [🔍HTTP protocol](https://en.wikipedia.org/wiki/HTTP). 
+This dynamic is easily visible through your browser's developer tools. It is possible to monitor all traffic related to a 
+specific site, including features such as [🔍Status Code](https://www.rfc-editor.org/rfc/rfc9110.html#name-status-codes) 
+and [🔍many others](https://developer.chrome.com/docs/devtools/network).
+
+Each entry in the request list represents a unique interaction, and a website can have dozens of them for content formation. 
+Among the various pieces of information provided, we will highlight one of the [🔍HTTP Headers](https://developer.mozilla.org/en-US/docs/Glossary/HTTP_header) 
+that says a lot about your server: the **Response Header**.
+
+>**Disclaimer:** OWASP does not endorse any vendor or tool by mentioning it. If it is cited, it is because we believe it 
+> is available for free use in open-source projects. Feel free to use the tool that best suits your needs.
+
+## Response Header
+It refers to a set of information exchanged between the client and the server. Although it is customizable, there is a 
+[🔍well-defined standard](https://developer.mozilla.org/en-US/docs/Glossary/Response_header) regarding its structure, content, 
+and usage. Due to this flexibility, it is commonly manipulated by attackers, so it is important for developers to be cautious 
+and not blindly trust this content.
+
+To observe them, we will use the browser's [🔍DevTools](https://developer.chrome.com/docs/devtools) from [Brave](https://brave.com/download/). 
+With the browser open, activate the [🔍Network](https://developer.chrome.com/docs/devtools/network) tab and keep it open 
+while visiting a site, such as https://owasp.org/. By [inspecting one of the items](https://developer.chrome.com/docs/devtools/network#details) 
+that appear in the request list, you'll have access to the **Headers** tab, where you'll find the **Response Headers** section.
+
+The information contained there will vary depending on the configuration of the server, application, or service accessed. 
+There is no correct list of what should exist or its composition, as it generally depends on each site's needs. However, 
+we know what definitely <u>should not exist</u> when we talk about cybersecurity.
+
+In its list of best practices, [OWASP](https://owasp.org/) gathers a series of recommendations, such as [🔍suggested secure content](https://owasp.org/www-project-secure-headers/index.html) 
+and [🔍what to avoid](https://owasp.org/www-project-secure-headers/index.html#prevent-information-disclosure-via-http-headers) 
+in the **Response Headers**.
+
+## Verifying if it was effective
+There are online tools that help you identify and check not only the **Response Headers**, but also other significant data:
+
+- [Security Header](https://securityheaders.com/?q=https%3A%2F%2Fowasp.org%2F&followRedirects=on): In addition to a score, 
+the site gives you a brief description and the importance of each header.
+- [Protocol Guard](https://protocolguard.com/scan/owasp.org): Besides guidance on each header, it also mentions some issues 
+related to [🔍SSL/TLS Ciphers](https://www.ssl.com/article/what-is-ssl-tls-an-in-depth-guide/).
+
+Among the **Response Headers**, two stand out: [🔍HTTP Strict Transport Security (HSTS)](https://www.ssl.com/article/what-is-http-strict-transport-security-hsts/) 
+and [🔍Content Security Policies (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP).
+
+While HSTS aims to protect sites from protocol downgrade attacks and cookie hijacking by enforcing interaction only via 
+secure HTTPS, CSP seeks to do the same with the static content your server provides (e.g., JavaScript), mitigating cross-site attacks. 
+Both headers share a common trait: they must be implemented gradually and carefully, monitoring the final behavior, as this 
+depends heavily on how the application and/or site was designed.
+
+To support this analysis, here are some useful tools:
+
+- [CSP Policy Evaluator](https://csper.io/evaluator): Based on a URL, this tool highlights the issues and provides details 
+on how to properly resolve them.
+- [Google CSP Evaluator](https://csp-evaluator.withgoogle.com/): From a URL or a set of CSP policies, this tool offers 
+guidance on each rule.
+- [Qualys SSLLabs](https://www.ssllabs.com/ssltest/analyze.html?d=owasp.org): Deeply analyzes SSL configurations, detailing 
+certificates and keys, as well as the existence of the HSTS header.
+- [HSTS Preload](https://hstspreload.org/): Evaluates whether your HSTS policies are eligible for the preload attribute, 
+a feature that, while not part of the original specification, provides security value by ensuring your application is included 
+in centralized lists like the [🔍Chromium list](https://www.chromium.org/hsts/) or the [🔍Firefox list](https://searchfox.org/comm-central/source/mozilla/security/manager/ssl/nsSTSPreloadList.inc).
+
+## Why is this important?
+Correctly configuring the **Response Headers** is crucial for several reasons:
+
+- **Security:** Improper configuration can expose sensitive information about the server or application, making it easier 
+for attacks like information disclosure or injection attacks.
+- **Privacy:** Some response headers may contain personal user information, such as cookies or authentication tokens. Configuring 
+them correctly helps protect user privacy and prevents data leaks.
+- **Attack prevention:** Well-configured headers can help prevent attacks like 🔍[🔍Cross-Site Scripting (XSS)](https://owasp.org/www-community/attacks/xss/),
+[🔍 Cross-Site Request Forgery (CSRF)](https://owasp.org/www-community/attacks/csrf), and [🔍Clickjacking](https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html), 
+by providing appropriate security policies.
+- **Performance improvement:** Some response headers can influence browser caching, improving site performance by reducing 
+the number of requests made to the server.
+- **Compatibility:** Configuring the response headers ensures compatibility with different browsers and devices, providing 
+a consistent user experience.
+
+## Summary
+Paying attention to **Response Headers** is a good starting point for ensuring the protection of your application or website. 
+Although these are simple configurations – _and in some cases, trivial) – they are crucial for adding an extra layer of security 
+to your environment. It’s important to remember that improper configuration can reveal sensitive characteristics of your 
+environment, which could be exploited by attackers.
+
+Following OWASP guidelines will help you on the journey to keep your systems protected against certain attack vectors. Proper 
+configuration of **Response Headers** also contributes to user privacy, improves performance, and ensures site compatibility.
+
+---
+
+| [⬆️Return to index](../index.md) | Go to Act 2 (soon) |
+|----------------------------------|--------------------|

--- a/pages/initiatives/isc_handler_roadmap/acts/act_1.pt-BR.md
+++ b/pages/initiatives/isc_handler_roadmap/acts/act_1.pt-BR.md
@@ -1,0 +1,106 @@
+---
+
+layout: col-sidebar
+title: "Ato I - Observando por trás da cortina"
+author: "Raphael Moreira"
+contributors: 
+permalink: /initiatives/isc_handler_roadmap/acts
+tags: ["cybersecurity", "protocol", "http", "network", "response header", "xss", "csrf", "clickjacking", hsts", "csp", "ssl"]
+
+---
+
+{% include writers.html %}
+
+[🇺🇸](act_1.md) | 🇧🇷
+
+# Ato I - Observando por trás da cortina
+Sempre que um site é acessado, uma série de processos ocorre nos bastidores através do protocolo [🔍Http](https://pt.wikipedia.org/wiki/Hypertext_Transfer_Protocol). Essa dinâmica 
+é facilmente visível por meio das ferramentas de desenvolvedor do seu navegador. Nele é possível monitorar todo o tráfego 
+relacionado a um determinado site, incluindo características como [🔍Código de Estado (Status Code)](https://www.rfc-editor.org/rfc/rfc9110.html#name-status-codes) e [🔍muitos outros](https://developer.chrome.com/docs/devtools/network?hl=pt-br).
+
+Cada entrada na lista de requisições representa uma interação única, sendo possível a um site ter dezenas delas para 
+formação do conteúdo. Dentre as diversas informações fornecidas, vamos destacar aqui um dos [🔍Cabeçalhos Http](https://developer.mozilla.org/en-US/docs/Glossary/HTTP_header)
+que diz muito sobre seu servidor: o **Cabeçalho de Resposta**.
+
+>**Aviso legal:** o OWASP não endossa nenhum vendedor ou ferramenta ao mencioná-lo. Se ele é citado, é porque acreditamos
+> que esteja disponível gratuitamente para uso em projetos de código aberto. Sinta-se livre para usar a ferramenta que
+> mais se adequa à sua necessidade.
+
+## Cabeçalho de Resposta
+Trata-se de um conjunto de informações passadas entre cliente e servidor. Ainda que seja personalizável, há um 
+[🔍padrão bem definido](https://developer.mozilla.org/en-US/docs/Glossary/Response_header) sobre sua estrutura, conteúdo e uso. Por conta dessa flexibilidade, é comumente manipulado por 
+invasores, logo, é importante que os desenvolvedores se atentem a não confiar cegamente nesse conteúdo.
+
+Para observá-los, usaremos o [🔍DevTools](https://developer.chrome.com/docs/devtools?hl=pt-br) do navegador [Brave](https://brave.com/pt-br/download/). Com o navegador aberto, 
+ative a aba [🔍Rede (Network)](https://developer.chrome.com/docs/devtools/network?hl=pt-br) e mantenha-na assim enquanto visita um site, como `https://owasp.org/`. Ao [inspecionar um dos itens](https://developer.chrome.com/docs/devtools/network?hl=pt-br#details) 
+que aparecem na lista de requisições, você terá acesso a aba **Cabeçalho (Headers)**, onde encontrará a seção 
+**Cabeçalho de Resposta (Response Header)**.
+
+A informação contida ali irá variar conforme a configuração do servidor, aplicação ou serviço acessado. Não há uma lista 
+correta do que deve existir, ou sua composição, pois em linhas gerais, depende da necessidade de cada site, contudo, 
+sabemos o que definitivamente <u>não deve existir</u>, quando falamos de cibersegurança.
+
+Em sua lista de boas práticas, o [OWASP](https://owasp.org/) reúne uma série de recomendações, como [🔍conteúdo seguro sugerido](https://owasp.org/www-project-secure-headers/index.html) e 
+[🔍o que evitar](https://owasp.org/www-project-secure-headers/index.html#prevent-information-disclosure-via-http-headers) no **Cabeçalho de Resposta**.
+
+## Verificando se surtiu efeito
+Existem ferramentas online que te auxiliam na identificação e conferência não só do **Cabeçalho de Resposta**, como outros
+dados significativos:
+
+- [Security Header](https://securityheaders.com/?q=https%3A%2F%2Fowasp.org%2F&followRedirects=on): além de uma nota, o site 
+lhe dá uma breve descrição e importância sobre cada cabeçalho.
+- [Protocol Guard](https://protocolguard.com/scan/owasp.org): além das orientações sobre cada cabeçalho, ele cita algumas falhas
+relacionada a [🔍Cifras SSL/TLS](https://www.ssl.com/pt/artigo/o-que-%C3%A9-ssl-tls-an-in-depth-guide/).
+
+Dentre os **Cabeçalhos de Resposta**, vale destacar aqui 2 deles: o [🔍Transporte Estrito de Segurança (HSTS)](https://www.ssl.com/pt/artigo/o-que-%C3%A9-http-transporte-estrito-seguran%C3%A7a-hsts/)
+e o [🔍Políticas de Segurança de Conteúdo (CSP)](https://developer.mozilla.org/pt-BR/docs/Web/HTTP/CSP).
+
+Enquanto o HSTS visa proteger sites contra ataques de downgrade de protocolo e sequestro de cookies, forçando a 
+interação somente via HTTPS seguras, o CSP busca fazer o mesmo com o conteúdo estático que seu servidor disponibiliza (javascript, por exemplo), 
+mitigando ataques cruzados. Ambos os cabeçalhos possuem uma característica em comum: devem ser inseridos de forma controlada, 
+aos poucos, observando-se o comportamento final, pois depende muito de como a aplicação e/ou site foi concebido.
+
+Para apoiar essa análise, temos as seguintes ferramentas:
+
+- [CSP Policy Evaluator](https://csper.io/evaluator): a partir de uma Url, esta ferramenta lhe aponta as falhas e dá detalhes
+    de como resolvê-los adequadamente.
+- [Google CSP Evaluator](https://csp-evaluator.withgoogle.com/): a partir de uma Url ou um conjunto de políticas CSP, esta ferramenta
+ lhe dá orientações sobre cada regra.
+- [Qualys SSLLabs](https://www.ssllabs.com/ssltest/analyze.html?d=owasp.org): analisa profundamente as configurações SSL, detalhando
+  certificados e chaves, bem como a existência do cabeçalho HSTS.
+- [HSTS Preload](https://hstspreload.org/): avalia se suas políticas HSTS são elegíveis para uso do atributo [preload](https://developer.mozilla.org/pt-BR/docs/Web/HTTP/Headers/Strict-Transport-Security#pr%C3%A9-carregamento_-_strict_transport_security),
+um recurso que, embora não faça parte da especificação original, tem seu valor de segurança ao garantir que sua aplicação fará
+parte das listas centralizadas como a [🔍lista Chromium](https://www.chromium.org/hsts/) ou [🔍lista Firefox](https://searchfox.org/comm-central/source/mozilla/security/manager/ssl/nsSTSPreloadList.inc).
+
+## Por que isso é importante?
+Configurar corretamente os **Cabeçalhos de Resposta** é crucial por várias razões:
+
+- **Segurança**: a má configuração pode expor informações sensíveis sobre o servidor ou aplicação, 
+facilitando ataques como a divulgação de informações confidenciais (disclosure) ou ataques de injeção.
+
+- **Privacidade**: alguns cabeçalhos de resposta podem conter informações pessoais dos usuários, como cookies ou tokens 
+de autenticação. Configurá-los ajuda corretamente a proteger a privacidade dos usuários, evitando vazamento de informações.
+
+- **Prevenção de ataques**: cabeçalhos bem configurados podem ajudar a prevenir ataques como [🔍Cross-Site Scripting (XSS)](https://owasp.org/www-community/attacks/xss/), 
+[🔍 Cross-Site Request Forgery (CSRF)](https://owasp.org/www-community/attacks/csrf) e [🔍Clickjacking](https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html), fornecendo políticas de segurança apropriadas.
+
+- **Melhoria no desempenho**: alguns cabeçalhos de resposta podem influenciar o cache do navegador, permitindo uma melhor 
+desempenho do site ao reduzir o número de solicitações feitas ao servidor.
+
+- **Compatibilidade**: configurar os cabeçalhos de resposta garante corretamente a compatibilidade com diferentes navegadores 
+e dispositivos, proporcionando uma experiência consistente aos usuários.
+
+## Resumo
+A atenção aos **Cabeçalhos de Resposta** é um bom ponto de partida para assegurar proteção à sua aplicação ou site. Embora
+sejam configurações simples - _e em alguns casos, triviais_ -, são cruciais para acrescentar uma camada adicional em seu ambiente. 
+Vale lembrar que se for mal configurado, pode relevar características sigilosas do seu ambiente, que podem ser explorados 
+pelos atacantes. 
+
+Seguir as diretrizes do OWASP irá ajudá-lo na jornada de manter seus sistemas protegidos contra alguns vetores de ataque. 
+A configuração adequada dos **Cabeçalhos de Resposta** também contribui para a privacidade dos usuários, melhora no desempenho 
+e na compatibilidade do site.
+
+---
+
+| [⬆️Retornar ao índice](../index.pt-BR.md) | Ir para o Ato 2 (breve) |
+|-------------------------------------------|-------------------------|

--- a/pages/initiatives/isc_handler_roadmap/acts/prologue.md
+++ b/pages/initiatives/isc_handler_roadmap/acts/prologue.md
@@ -42,6 +42,6 @@ learning, try to internalize the culture of protecting the environment you work 
 
 ---
 
-| [⬆️Return to index](../index.md) | Go to Act 1 (soon)➡️ |
-|----------------------------------|----------------------|
+| [⬆️Return to index](../index.md) | [Go to Act 1](act_1.md)➡️ |
+|----------------------------------|---------------------------|
 

--- a/pages/initiatives/isc_handler_roadmap/acts/prologue.md
+++ b/pages/initiatives/isc_handler_roadmap/acts/prologue.md
@@ -1,0 +1,47 @@
+---
+
+layout: col-sidebar
+title: "Prologue - Preparation"
+author: "Raphael Moreira"
+contributors: 
+permalink: /initiatives/isc_handler_roadmap/acts
+tags: ["cybersecurity", "kali", "linux", "environment", "virtualization"]
+
+---
+
+{% include writers.html %}
+
+🇺🇸 | [🇧🇷](prologue.pt-BR.md)
+
+# Prologue - Preparation
+Aiming for objectivity and security in the learning process, the following steps will guide you in creating a [🔍virtualized Linux environment](https://www.redhat.com/en/topics/virtualization/what-is-virtualization). 
+For reference, we will be using **Microsoft Windows 10 Pro**, version **22H2**, build **19045.4123**. The suggested 
+distribution is [🔍Kali Linux](https://www.kali.org/).
+
+>**Disclaimer:** the OWASP does not endorse any vendor or tool by mentioning it. If it is cited, it is because we believe 
+> it is available for free use in open-source projects. Feel free to use the tool that best suits your needs.
+
+## Kali Linux
+The [🔍Kali distribution](https://www.kali.org/features/) is dedicated to cybersecurity, providing a set of tools ideal 
+for the task. If you're more comfortable with another distribution, there's no need to switch to Kali, as throughout the acts, 
+there will be guidance on each tool and how to obtain it. On the official Kali site, you'll find various [platforms](https://www.kali.org/get-kali/#kali-platforms) 
+available for use. However, for our initiative, we will be using [VMware](https://cdimage.kali.org/kali-2024.1/kali-linux-2024.1-vmware-amd64.7z). 
+If you’re not comfortable with this virtualization tool, the site also offers [other options](https://www.kali.org/get-kali/#kali-virtual-machines).
+
+>**WARNING:** make sure your operating system has [🔍Hyper-V](https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/about/) 
+> enabled; otherwise, you will encounter issues with virtualization.
+
+## Recommendations
+Once your environment is functional, meaning it is virtualized and running, remember that everything we will demonstrate 
+throughout this initiative requires elevated privileges (administrative access). However, it is highly recommended that 
+you do not use the **root** user. Try to create another user and mark it as **Administrator**. Although it may seem the same, 
+it is not. The **root** user has privileges that can put you at risk if used improperly.
+
+In the case of virtualization, ensure that encryption for this image is enabled. Even if you are at the initial stage of 
+learning, try to internalize the culture of protecting the environment you work in, thus ensuring the privacy of your work.
+
+---
+
+| [⬆️Return to index](../index.md) | Go to Act 1 (soon)➡️ |
+|----------------------------------|----------------------|
+

--- a/pages/initiatives/isc_handler_roadmap/acts/prologue.pt-BR.md
+++ b/pages/initiatives/isc_handler_roadmap/acts/prologue.pt-BR.md
@@ -44,6 +44,6 @@ privacidade do seu trabalho.
 
 ---
 
-| [⬆️Retornar ao índice](../index.pt-BR.md) | Ir para o Ato 1 (breve)➡️ |
-|-------------------------------------------|---------------------------|
+| [⬆️Retornar ao índice](../index.pt-BR.md) | [Ir para o Ato 1](act_1.pt-BR.md)➡️ |
+|-------------------------------------------|-------------------------------------|
 

--- a/pages/initiatives/isc_handler_roadmap/acts/prologue.pt-BR.md
+++ b/pages/initiatives/isc_handler_roadmap/acts/prologue.pt-BR.md
@@ -1,0 +1,49 @@
+---
+
+layout: col-sidebar
+title: "Ato 0 - Preparação"
+author: "Raphael Moreira"
+contributors: 
+permalink: /initiatives/isc_handler_roadmap/acts
+tags: ["cybersecurity", "kali", "linux", "environment", "virtualization"]
+
+---
+
+{% include writers.html %}
+
+[🇺🇸](prologue.md) | 🇧🇷
+# Prólogo - Preparação
+Visando objetividade e segurança no processo de aprendizagem, as etapas a seguir irão orientá-lo na criação de um 
+[🔍ambiente virtualizado Linux](https://www.redhat.com/pt-br/topics/virtualization/what-is-virtualization). A título de referência, estaremos usando um **Microsoft Windows 10 Pro**, versão **22H2**, 
+compilação **19045.4123**. A distribuição sugerida é a [🔍Kali Linux](https://www.kali.org/).
+
+>**Aviso legal:** o OWASP não endossa nenhum vendedor ou ferramenta ao mencioná-lo. Se ele é citado, é porque acreditamos 
+> que esteja disponível gratuitamente para uso em projetos de código aberto. Sinta-se livre para usar a ferramenta que 
+> mais se adequa à sua necessidade.
+
+## Kali Linux
+A [🔍distribuição Kali](https://www.kali.org/features/) é dedicada a cibersegurança, provendo um conjunto de ferramentas propícias para a tarefa. 
+Se você tem afinidade com outra distribuição, não é necessário trocá-lo pelo Kali, pois ao longo dos atos, haverá orientação 
+sobre cada ferramenta, e como obtê-la. No site oficial do Kali você encontra diversas [plataformas](https://www.kali.org/get-kali/#kali-platforms) de uso, contudo, 
+para nossa iniciativa, usaremos o [VMware](https://cdimage.kali.org/kali-2024.1/kali-linux-2024.1-vmware-amd64.7z). Caso não se sinta à vontade com essa ferramenta de virtualização, o site 
+disponibiliza [outras opções](https://www.kali.org/get-kali/#kali-virtual-machines).
+
+>**ATENÇÃO:** certifique de que seu sistema operacional possui o 
+> [🔍Hyper-V](https://learn.microsoft.com/pt-br/virtualization/hyper-v-on-windows/about/) habilitado, caso contrário,
+> terá problemas com a virtualização.
+
+## Recomendações
+Assim que seu ambiente estiver funcional, isto é, virtualizado e executando, lembre-se que tudo o que vamos mostrar no decorrer 
+dessa iniciativa, requer elevação de privilégios (acesso administrativo). No entanto, é altamente recomendável que você não 
+use o usuário **root**. Procure criar outro, marcando-o como **Administrador**. Embora pareça o mesmo, não é. O usuário 
+**root** possui privilégios que pode te colocar em risco se usado de maneira incorreta.
+
+No caso de se tratar de uma virtualização, garanta a ativação da criptografia dessa imagem. Ainda que você esteja em estágio 
+inicial de aprendizado, procure internalizar a cultura da proteção do próprio ambiente em que trabalha, garantindo assim a 
+privacidade do seu trabalho.
+
+---
+
+| [⬆️Retornar ao índice](../index.pt-BR.md) | Ir para o Ato 1 (breve)➡️ |
+|-------------------------------------------|---------------------------|
+

--- a/pages/initiatives/isc_handler_roadmap/index.md
+++ b/pages/initiatives/isc_handler_roadmap/index.md
@@ -44,5 +44,8 @@ not mandatory, it is highly recommended that you possess the following combinati
 > without rushing, to fully grasp it before moving on. If you're here just out of curiosity, feel free to proceed without 
 > hesitation.
 
+# Journey
+
+- [Prologue - Preparation](acts/prologue.md);
 >_**Note¹**: The term "Handlers" is used in this context because, in the web protocol, "Handlers" are interception points 
 > where events occur, which can be observed, captured, or nullified._

--- a/pages/initiatives/isc_handler_roadmap/index.md
+++ b/pages/initiatives/isc_handler_roadmap/index.md
@@ -47,5 +47,7 @@ not mandatory, it is highly recommended that you possess the following combinati
 # Journey
 
 - [Prologue - Preparation](acts/prologue.md);
+- [Act I - Observing Behind the Curtain](acts/act_1.md);
+
 >_**Note¹**: The term "Handlers" is used in this context because, in the web protocol, "Handlers" are interception points 
 > where events occur, which can be observed, captured, or nullified._

--- a/pages/initiatives/isc_handler_roadmap/index.md
+++ b/pages/initiatives/isc_handler_roadmap/index.md
@@ -1,0 +1,48 @@
+﻿---
+
+layout: col-sidebar
+title: "ISC - The Path to Becoming a Handler"
+author: "Raphael Moreira"
+contributors: 
+permalink: /initiatives/isc_handler_roadmap/
+tags: ["cybersecurity", "roadmap"]
+
+---
+
+{% include writers.html %}
+
+🇺🇸 | [🇧🇷](index.pt-BR.md)
+
+# ISC - The Path to Becoming a Handler
+Handlers¹ are volunteer professionals who generously donate their valuable time to detect and investigate incidents and 
+anomalies arising from cyberattacks. Currently composed of [16 people](https://isc.sans.edu/handler_list.html), the Handlers 
+regularly contribute on the topic by developing ideas, providing insights, or presenting real cases in an educational manner.
+
+The journey to becoming a Handler is long, filled with challenges and discoveries. The [official roadmap](https://isc.sans.edu/handlerroadmap.html) 
+contains detailed information about the process as well as the requirements to be met. Among them, we will highlight:
+
+1. [GIAC Certification](http://www.giac.org/) or significant contribution in the field.
+
+If you have no idea what the GIAC certification is about and have zero contributions to the community, don’t be discouraged, 
+as every goal needs a starting point, and that’s the purpose of this initiative.
+
+> **WARNING**: The techniques demonstrated in this content are the same ones used by cybercriminals in attempts to gain an advantage 
+> over a service or company. However, the purpose of this material is to guide new specialists in the field so that together 
+> we can increasingly protect our systems. Be ethical. Be responsible.
+
+# Technical Requirements
+It is of utmost importance that certain requirements are met to make the journey smoother and more understandable. Although 
+not mandatory, it is highly recommended that you possess the following combination of skills and knowledge:
+
+- Advanced programming experience (in any language);
+- Proficiency in using the Linux operating system (any distribution);
+- Understanding of protocols and networks (TCP, UDP, etc.);
+- Autonomy in learning.
+
+> **WARNING**: The roadmap does not aim to detail every aspect or tool used. Therefore, whenever you encounter the 🔍️ icon, 
+> interpret it as an indication that understanding this item is crucial. It is highly recommended that you take your time, 
+> without rushing, to fully grasp it before moving on. If you're here just out of curiosity, feel free to proceed without 
+> hesitation.
+
+>_**Note¹**: The term "Handlers" is used in this context because, in the web protocol, "Handlers" are interception points 
+> where events occur, which can be observed, captured, or nullified._

--- a/pages/initiatives/isc_handler_roadmap/index.pt-BR.md
+++ b/pages/initiatives/isc_handler_roadmap/index.pt-BR.md
@@ -46,6 +46,7 @@ não seja mandatório, é altamente recomendável que você possua a seguinte co
 # Jornada
 
 - [Prólogo - Preparação](acts/prologue.pt-BR.md);
+- [Ato I - Observando por trás da cortina](acts/act_1.pt-BR.md);
 
 >_**Nota da tradução¹**: o nome Handlers (Manipuladores, em tradução livre) é usado nesse contexto, pois no protocolo web, 
 "Handlers" são pontos de passagem onde eventos ocorrem, podendo ser observados, capturados ou anulados._ 

--- a/pages/initiatives/isc_handler_roadmap/index.pt-BR.md
+++ b/pages/initiatives/isc_handler_roadmap/index.pt-BR.md
@@ -1,0 +1,47 @@
+﻿---
+
+layout: col-sidebar
+title: "ISC - O roteiro para se tornar um Handler"
+author: "Raphael Moreira"
+contributors: 
+permalink: /initiatives/isc_handler_roadmap/
+tags: ["cybersecurity", "roadmap"]
+
+---
+
+{% include writers.html %}
+
+[🇺🇸](index.md) | 🇧🇷
+# ISC - O roteiro para se tornar um Handler
+Handlers¹ são profissionais voluntários que doam seu valioso tempo na detecção e investigação de incidentes e anomalias, 
+provenientes de ataques cibernéticos. Atualmente formado por [16 pessoas](https://isc.sans.edu/handler_list.html), os Handlrers contribuem regularmente sobre o 
+tema, seja elaborando ideias, pontuando observações ou apresentando casos reais de forma educativa.
+
+A jornada para se tornar um Handler é longa, envolta de desafios e descobertas. O [roadmap oficial](https://isc.sans.edu/handlerroadmap.html)
+contém detalhes minuciosos sobre o processo, bem como os requisitos a serem atendidos. Dentre eles, destacaremos aqui a:
+
+1. [Certificação GIAC](http://www.giac.org/) ou uma significante contribuição na área.
+
+Se você não faz ideia do que trata o certificado GIAC e tem zero contribuição na comunidade, não desanime, pois todo objetivo 
+precisa de um início, e é esse o propósito dessa iniciativa.
+
+> **ATENÇÃO**: as técnicas demonstradas nesse conteúdo são as mesmas usadas por cibercriminosos, na tentativa de obter vantagem
+> sobre um serviço ou empresa. Contudo, o intuito desse material é orientar novos especialistas no assunto, para que juntos 
+> possamos, cada vez mais, proteger nossos sistemas. Seja ético. Seja responsável.
+
+# Requisitos Técnicos
+É de suma importância que alguns requisitos sejam atendidos, a título de tornar o caminho mais leve e compreensível. Embora 
+não seja mandatório, é altamente recomendável que você possua a seguinte combinação de habilidades e conhecimento:
+
+- Experiência avançada em programação (qualquer linguagem);
+- Proficiência no uso do sistema operacional Linux (qualquer distribuição);
+- Compreensão de protocolos e redes (tcp, udp, etc...);
+- Autonomia para aprender.
+
+> **ATENÇÃO**: o roteiro não visa detalhar minuciosamente cada aspecto ou ferramenta utilizada, portanto, sempre que 
+> se deparar com o ícone 🔍️, interprete-o como um indicativo de que o entendimento sobre este item é crucial, portanto, 
+> é altamente recomendável que você dedique, sem pressa, um tempo considerável entendendo-o, antes de prosseguir. Caso 
+> você esteja aqui apenas pela curiosidade, siga em frente sem receio.
+
+>_**Nota da tradução¹**: o nome Handlers (Manipuladores, em tradução livre) é usado nesse contexto, pois no protocolo web, 
+"Handlers" são pontos de passagem onde eventos ocorrem, podendo ser observados, capturados ou anulados._ 

--- a/pages/initiatives/isc_handler_roadmap/index.pt-BR.md
+++ b/pages/initiatives/isc_handler_roadmap/index.pt-BR.md
@@ -43,5 +43,9 @@ não seja mandatório, é altamente recomendável que você possua a seguinte co
 > é altamente recomendável que você dedique, sem pressa, um tempo considerável entendendo-o, antes de prosseguir. Caso 
 > você esteja aqui apenas pela curiosidade, siga em frente sem receio.
 
+# Jornada
+
+- [Prólogo - Preparação](acts/prologue.pt-BR.md);
+
 >_**Nota da tradução¹**: o nome Handlers (Manipuladores, em tradução livre) é usado nesse contexto, pois no protocolo web, 
 "Handlers" são pontos de passagem onde eventos ocorrem, podendo ser observados, capturados ou anulados._ 


### PR DESCRIPTION
# About the content
The philosophy behind this content is to create a learning path and best practices in security, evolving with each act to focus on a specific aspect. To encourage the consumption of this content, I based it on the [Internet Storm Center](https://isc.sans.edu/handler_list.html) program, which emphasizes volunteering by security professionals. In other words: you can become one too.

Considering that OWASP Pages has a lot of content, I decided to start this project to condense all the knowledge, attempting to create a chronological journey. After all, there is already a lot of branched content, and the idea is to organize and centralize things.

In this first PR, I’m adding the homepage (prologue with context) and the first act, which talks about response headers.

>_Note: Although there is no defined standard, I took the liberty of creating a Brazilian Portuguese (pt-Br) version and appropriately directing the links. If this type of action is not permitted, please let me know so I can remove it and keep it only in `en-us`_.

Thank you.