### PR TITLE
Removing Kroogal, unless proven otherwise there is no tool

### DIFF
--- a/_data/tools.json
+++ b/_data/tools.json
@@ -1584,15 +1584,6 @@
       "type": "SAST"
    },
    {
-      "title": "Kroogal",
-      "url": "http://www.kroogal.com/",
-      "owner": null,
-      "license": "Commercial",
-      "platforms": null,
-      "note": "C, C++",
-      "type": "SAST"
-   },
-   {
       "title": "Horusec",
       "url": "https://github.com/ZupIT/horusec",
       "owner": null,


### PR DESCRIPTION
The website looks like it's used to find spearfishing targets. 100% anonymous, no evidence of a tool existing....

Commercial licence but no legal entity behind it?