### PR TITLE
Update Using_freed_memory.md remove unaware section

### DIFF
--- a/pages/vulnerabilities/Using_freed_memory.md
+++ b/pages/vulnerabilities/Using_freed_memory.md
@@ -30,10 +30,8 @@ and sometimes overlapping causes:
     the memory
 
 Use after free errors sometimes have no effect and other times cause a
-program to crash. While it is technically feasible for the freed memory
-to be re-allocated and for an attacker to use this reallocation to
-launch a buffer overflow attack, we are unaware of any exploits based on
-this type of attack.
+program to crash or to exploit another memory-based vector to compromise
+the system.
 
 The use of previously freed memory can have any number of adverse
 consequences - ranging from the corruption of valid data to the

--- a/pages/vulnerabilities/Using_freed_memory.md
+++ b/pages/vulnerabilities/Using_freed_memory.md
@@ -14,7 +14,9 @@ auto-migrated: 1
 
 # Description
 
-Referencing memory after it has been freed can cause a program to crash.
+Referencing memory after it has been freed can cause a program to crash. 
+Examples of this would include RomCom's use of  CVE-2024-9680 [1] and 
+CVE-2024-49039 [2] to drop RomCom's Rat tool on an exploited system.
 
 The use of heap allocated memory after it has been freed or deleted
 leads to undefined system behavior and, in many cases, to a
@@ -135,3 +137,9 @@ shellcode, execution of arbitrary code can be achieved.
     memory they point to has been freed can be effective strategy. The
     utilization of multiple or complex data structures may lower the
     usefulness of this strategy.
+
+# References
+
+[1] CVE-2024-9680; https://nvd.nist.gov/vuln/detail/CVE-2024-9680
+
+[2] CVE-2024-49039; https://nvd.nist.gov/vuln/detail/CVE-2024-49039


### PR DESCRIPTION
update description and remove "we are unaware of exploits" section since  RomCom's use of  CVE-2024-9680 (Firefox) and CVE-2024-49039 (Windows) to drop RomCom's Rat tool are currently active.