### PR TITLE
remove ThreatDragon from GSoC 2025

### DIFF
--- a/pages/initiatives/gsoc/gsoc2025ideas.md
+++ b/pages/initiatives/gsoc/gsoc2025ideas.md
@@ -7,7 +7,7 @@ permalink: /initiatives/gsoc/gsoc2025ideas
 
 # {{page.title}}
 
-[Bug Logging Tool (BLT)](#bug-logging-tool-blt) &bull;  [Juice Shop](#owaspjuiceshop) &bull; [DevSecOps Maturity Model](#owaspdevsecops-maturity-model) &bull; [OWASP OWTF](#owasp-owtf) &bull; [OWASP secureCodeBox](#owasp-securecodebox) &bull; [OWASP Nettacker](#owasp-nettacker) &bull; [OWASP Threat Dragon](#owasp-threat-dragon) &bull; [OWASP Website](#owasp-website) &bull; [OWASP Nest](#owasp-nest)
+[Bug Logging Tool (BLT)](#bug-logging-tool-blt) &bull;  [Juice Shop](#owaspjuiceshop) &bull; [DevSecOps Maturity Model](#owaspdevsecops-maturity-model) &bull; [OWASP OWTF](#owasp-owtf) &bull; [OWASP secureCodeBox](#owasp-securecodebox) &bull; [OWASP Nettacker](#owasp-nettacker) &bull; [OWASP Website](#owasp-website) &bull; [OWASP Nest](#owasp-nest)
 
 
 <!-- Template: Use a format like below to add your project, don't forget to add it to the anchor links above:
@@ -325,42 +325,6 @@ Repositories:
 * [Sam Stepanyan](mailto:sam.stepanyan@owasp.org)
 * [Ali Razmjoo](mailto:ali.razmjoo@owasp.org)
 * [Arkadii Yakovets](mailto:arkadii.yakovets@owasp.org)
-
-### [OWASP Threat Dragon](https://owasp.org/www-project-threat-dragon/)
-
-OWASP Threat Dragon is a modeling tool used to create threat model diagrams as part of a secure development lifecycle.
-
-![Difficulty: Medium](https://img.shields.io/badge/difficulty-medium-orange)
-![Preferred for "Medium" GSoC 2025 project](https://img.shields.io/badge/medium%20size%20(~175h)-preferred-green)
-
-##### Explanation of Ideas
-
-The threat engine has two features that have not yet been carried over from version 1.x to the current version 2.x.
-These need to be implemented and expanded from what is available in version 1.x; both ideas are independent GSoC projects:
-
-- add threats by element for STRIDE/LINDDUN/PLOT4ai [issue #792](https://github.com/OWASP/threat-dragon/issues/792)
-- add threats using OWASP Automated Threats (OATs) patterns [issue #501](https://github.com/OWASP/threat-dragon/issues/501)
-
-##### Getting Started
-
-- Browse the [documentation](https://owasp.org/www-project-threat-dragon/docs-2/) to see if Threat Dragon is for you
-- Join OWASP Slack and contact the Threat Dragon community on channel [#project-threat-dragon](https://app.slack.com/client/T04T40NHX/CURE8PQ68)
-- Refer to the Threat Dragon [contributing guidelines](https://github.com/OWASP/threat-dragon/blob/main/contributing.md)
-
-Repositories:
-
-- [OWASP Threat Dragon on OWASP GitHub](https://github.com/OWASP/threat-dragon)
-
-##### Knowldege  Requirements
-
-- Javascript
-- Node.js
-- git
-
-##### Mentors
-
-* [Jon Gadsden](mailto:jon.gadsden@owasp.org)
-
 
 ### [OWASP Website](https://owasp.org)
 


### PR DESCRIPTION
The Threat Dragon project is not intending to enter for GSoC 2025,
only because there is not an obvious self-contained feature for this year