### PR TITLE
Update Memory_leak.md

### DIFF
--- a/pages/vulnerabilities/Memory_leak.md
+++ b/pages/vulnerabilities/Memory_leak.md
@@ -67,8 +67,6 @@ int main(int argc, char **argv)
 
 - In this example, we have 10 allocations of size MAXSIZE. Every allocation, with the exception of the last, is lost. If no pointer is pointed to the allocated block, it is unrecoverable during program execution. A simple fix to this trivial example is to place the `free()` call inside of the 'for' loop.
 
-- [Here](http://www.securiteam.com/securitynews/5ZP0M1PIUI.html) is a real world example of a memory leak causing denial of service
-
 ### Example 2
 
 The following C function leaks a block of allocated memory if the call to `read()` fails to return the expected number of bytes:

--- a/pages/vulnerabilities/Memory_leak.md
+++ b/pages/vulnerabilities/Memory_leak.md
@@ -67,6 +67,8 @@ int main(int argc, char **argv)
 
 - In this example, we have 10 allocations of size MAXSIZE. Every allocation, with the exception of the last, is lost. If no pointer is pointed to the allocated block, it is unrecoverable during program execution. A simple fix to this trivial example is to place the `free()` call inside of the 'for' loop.
 
+- [Here](https://web.archive.org/web/20161012223329/http://www.securiteam.com/securitynews/5ZP0M1PIUI.html) is a real world example of a memory leak causing denial of service
+
 ### Example 2
 
 The following C function leaks a block of allocated memory if the call to `read()` fails to return the expected number of bytes:


### PR DESCRIPTION
Removed the real world "example" as it now redirects to another domain just displaying products: "https://www.fortra.com/product-lines/beyond-security"