### PR TITLE
Add line feed (0x0A) to CSV injection character escape list

### DIFF
--- a/pages/attacks/CSV_Injection.md
+++ b/pages/attacks/CSV_Injection.md
@@ -33,6 +33,7 @@ begin with any of the following characters:
 - At (`@`)
 - Tab (`0x09`)
 - Carriage return (`0x0D`)
+- Line feed (`0x0A`)
 
 Keep in mind that it is not sufficient to make sure that the untrusted user input does not start with these characters. You also need to take care of the field separator (e.g., '`,`', or '`;`') and quotes (e.g., `'`, or `"`), as attackers could use this to start a new cell and then have the dangerous character in the middle of the user input, but at the beginning of a cell.
 


### PR DESCRIPTION
## Description
Fixes #1115 

Added Line feed (`0x0A`) to the list of characters that should be escaped to prevent CSV injection attacks.

## Problem
The CSV Injection documentation page was missing the line feed character (`\n`, ASCII 0x0A) from the list of characters to escape. The original list only included carriage return (0x0D).

## Solution
Added "Line feed (`0x0A`)" to the bullet list in the remediation section.

## Why This Change Is Important
- Most Unix-based systems use `\n` as the default newline character
- Spreadsheets treat `\n` and `\r` similarly for row breaking
- User input containing `\n` can break CSV structure just like `\r`
- This provides more complete, platform-agnostic guidance for developers

## Testing
- [x] Verified the change renders correctly in markdown
- [x] Confirmed the addition maintains the existing formatting and structure
- [x] Ensured no breaking changes to existing content