### PR TITLE
Remove unmaintained insidersec sast tools

### DIFF
--- a/_data/tools.json
+++ b/_data/tools.json
@@ -1188,15 +1188,6 @@
       "type": "SAST"
    },
    {
-      "title": "Insider CLI",
-      "url": "https://github.com/insidersec/insider",
-      "owner": "InsiderSec",
-      "license": "Open Source or Free",
-      "platforms": null,
-      "note": "A open source Static Application Security Testing tool (SAST) written in GoLang for Java Maven and Android), Kotlin (Android), Swift (iOS), .NET Full Framework, C#, and Javascript (Node.js).",
-      "type": "SAST"
-   },
-   {
       "title": "MobSF",
       "url": "https://mobsf.github.io/Mobile-Security-Framework-MobSF/",
       "owner": null,


### PR DESCRIPTION
Last commit Jan 2021.
Linked insersec.io is down / taken over