### PR TITLE
Remove unmaintained sast Betterscan CE from tools list

### DIFF
--- a/_data/tools.json
+++ b/_data/tools.json
@@ -1530,15 +1530,6 @@
       "type": "SAST"
    },
    {
-      "title": "Betterscan CE (Community Edition)",
-      "url": "https://github.com/marcinguy/betterscan-ce",
-      "owner": "Marcin Kozlowski",
-      "license": "Open Source",
-      "platforms": null,
-      "note": "Code Scanning/SAST/Static Analysis/Linting using many tools/Scanners with One Report. Currently supports:  PHP, Java, Scala, Python, Ruby, Javascript, GO, Secret Scanning, Dependency Confusion, Trojan Source, Open Source and Proprietary Checks (total ca. 1000 checks). Supports also Differential analysis. Goal is to have one report using many tools/scanners",
-      "type": "SAST"
-   },
-   {
       "title": "Sentinel Source",
       "url": "https://www.whitehatsec.com/products/static-application-security-testing/",
       "owner": "Whitehat",


### PR DESCRIPTION
url is dead.
betterscan.io is dead.
A new url might be https://github.com/d-demirci/betterscan-ce, but last commit is Feb 2023.