### PR TITLE
Improve fuzz testing description in Fuzzing.md

### DIFF
--- a/pages/Fuzzing.md
+++ b/pages/Fuzzing.md
@@ -3,7 +3,7 @@
 title: Fuzzing
 layout: col-sidebar
 author:
-contributors:
+contributors: Marco Barbaccia
 tags:
 permalink: /Fuzzing
 
@@ -11,8 +11,7 @@ permalink: /Fuzzing
 
 {% include writers.html %}
 
-*Fuzz testing* or *Fuzzing* is a Black Box software testing technique, which basically consists in finding implementation bugs using
-malformed/semi-malformed data injection in an automated fashion.
+*Fuzz testing*, or *fuzzing*, is a software testing technique aimed at identifying bugs, vulnerabilities, or unexpected behavior by automatically providing a program with unexpected, malformed, or semi-malformed inputs.
 
 ## A trivial example
 


### PR DESCRIPTION
The original definition described fuzzing exclusively as a black-box technique. While technically correct in many cases, this definition is somewhat limited and imprecise. The revised version removes the black-box restriction to make the definition more general, since fuzzing can also be applied in grey-box or white-box contexts. Additionally, the wording has been made more formal and precise.