### PR TITLE
Create Abuse_of_Functionality

### DIFF
--- a/pages/attacks/Abuse_of_Functionality
+++ b/pages/attacks/Abuse_of_Functionality
@@ -23,6 +23,6 @@ of the intended attack, not the primary aim.
 
 ## References
 
-[Abuse Existing Functionality](https://capec.mitre.org/data/definitions/210.html)
+[CAPEC: Abuse Existing Functionality](https://capec.mitre.org/data/definitions/210.html)
 [Abuse of Functionality](http://projects.webappsec.org/w/page/13246913/Abuse%20of%20Functionality)
 [OWASP Automated Threat Handbook - Web Applications](https://owasp.org/www-project-automated-threats-to-web-applications/)


### PR DESCRIPTION
Created new page, reflecting what used to be the Abuse of Functionality attack description on the former OWASP wiki https://wiki.owasp.org/index.php/Category:Attack and https://wiki.owasp.org/index.php/Category:Abuse_of_Functionality