### PR TITLE
Revise GSoC 2026 ideas and mentor information

### DIFF
--- a/pages/initiatives/gsoc/gsoc2026ideas.md
+++ b/pages/initiatives/gsoc/gsoc2026ideas.md
@@ -86,7 +86,7 @@ We are actively looking for more mentors! If you have experience in **Django, Re
 - **Ahmed ElSheikh**  
 - _More coming soon, Contact Donnie on Slack if you'd like to Mentor_  
 
-🎥 _To get up to speed, check out our [BLT videos](https://owaspblt.org/education/).  
+🎥 _To get up to speed, check out our [BLT videos](https://owaspblt.org/education/)._
 
 
 ### [OWASP DevSecOps Maturity Model](https://dsomm.owasp.org)


### PR DESCRIPTION
Updated GSoC 2026 ideas for BLT by removing outdated project descriptions and adding a note about new projects coming soon. Adjusted mentor list and updated video links.