### PR TITLE
Fix for broken links to Threat Modeling project

### DIFF
--- a/pages/OWASP_Risk_Rating_Methodology.md
+++ b/pages/OWASP_Risk_Rating_Methodology.md
@@ -22,7 +22,7 @@ There are other more mature, popular, or well established Risk Rating Methodolog
 
 Alternatively you may with the review information about Threat Modeling, as that may be a better fit for your app or organization:
 
-- [OWASP Threat Modeling Project](https://owasp.org/www-project-threat-model/)
+- [OWASP Threat Modeling Project](https://owasp.org/www-project-threat-modeling/)
 - [OWASP pytm](https://owasp.org/www-project-pytm/) Pythonic framework for threat modeling
 - [OWASP Threat Dragon](https://owasp.org/www-project-threat-dragon/) threat modeling tool
 

--- a/pages/Threat_Modeling.md
+++ b/pages/Threat_Modeling.md
@@ -13,7 +13,7 @@ redirect_from:
 
 {% include writers.html %}
 
-This is an OWASP community page. You should also visit the official [Threat Model Project](https://owasp.org/www-project-threat-model/) site.
+This is an OWASP community page. You should also visit the official [Threat Model Project](https://owasp.org/www-project-threat-modeling/) site.
 
 ## Overview
 

--- a/pages/Threat_Modeling_Process.md
+++ b/pages/Threat_Modeling_Process.md
@@ -10,7 +10,7 @@ permalink: /Threat_Modeling_Process
 
 {% include writers.html %}
 
-This is an OWASP community page. You should also visit the official [Threat Model Project](https://owasp.org/www-project-threat-model/) site.
+This is an OWASP community page. You should also visit the official [Threat Model Project](https://owasp.org/www-project-threat-modeling/) site.
 
 - [Introduction](#introduction)
   - [Step 1: Scope your work](#step-1-scope-your-work)


### PR DESCRIPTION
The link to the Threat Modeling project pages has been fixed up for the new link URL:
https://owasp.org/www-project-threat-modeling/

Closes #1152 