### PR TITLE
Remove obsolete browser references and WebGoat HttpOnly testing section

### DIFF
--- a/pages/HttpOnly.md
+++ b/pages/HttpOnly.md
@@ -233,6 +233,18 @@ bool setcookie  ( string $name  [, string $value  [, int $expire= 0  [, string $
                  [, string $domain  [, bool $secure= false  [, bool $httponly= false  ]]]]]] )
 ```
 
+
+## Modern Browser Support
+
+HttpOnly is supported by all modern browsers, including:
+
+- Google Chrome (and Chromium-based Edge)
+- Mozilla Firefox
+- Apple Safari
+
+All actively maintained browsers correctly prevent client-side JavaScript
+from accessing cookies marked with the HttpOnly attribute.
+
 ### Web Application Firewalls
 
 If code changes are infeasible, web application firewalls can be used to
@@ -245,160 +257,6 @@ WAF[9](http://code.google.com/p/owasp-esapi-java/downloads/list)
 using *add-http-only-flag*
 directive[10](http://www.slideshare.net/llamakong/owasp-esapi-waf-appsec-dc-2009)
 
-## Browsers Supporting HttpOnly
-
-Using WebGoat's HttpOnly lesson, the following web browsers have been
-tested for HttpOnly support. If the browsers enforces HttpOnly, a client
-side script will be unable to read or write the session cookie. However,
-there is currently no prevention of reading or writing the session
-cookie via a XMLHTTPRequest.
-
-Note: These results may be out of date as this page is not well
-maintained. A great page that is focused on keeping up with the status
-of browsers is at: [Browserscope](http://www.browserscope.org/?category=security).
-Just look at the HttpOnly column. The Browserscope site does not provide
-as much detail on HttpOnly as this page, but provides lots of other
-details this page does not.
-
-Our results as of Feb 2009 are listed below in **table 1**.
-
-| **Browser**                 | **Version**                   | **Prevents Reads** | **Prevents Writes** | **Prevents Read within XMLHTTPResponse\***                                                                                                                                                        |
-| ----------------------------| ----------------------------- | ------------------ | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Microsoft Internet Explorer | 8 Beta 2                      | Yes                | Yes                 | Partially (set-cookie is protected, but not set-cookie2, see [11](http://www.microsoft.com/technet/security/bulletin/ms08-069.mspx)). Fully patched IE8 passes <http://ha.ckers.org/httponly.cgi> |
-| Microsoft Internet Explorer | 7                             | Yes                | Yes                 | Partially (set-cookie is protected, but not set-cookie2, see [12](http://www.microsoft.com/technet/security/bulletin/ms08-069.mspx)). Fully patched IE7 passes <http://ha.ckers.org/httponly.cgi> |
-| Microsoft Internet Explorer | 6 (SP1)                       | Yes                | No                  | No (Possible that ms08-069 fixed IE 6 too, please verify with <http://ha.ckers.org/httponly.cgi> and update this page\!)                                                                          |
-|                             |                               |                    |                     |                                                                                                                                                                                                   |
-| Microsoft Internet Explorer | 6 (fully patched)             | Yes                | Unknown             | Yes                                                                                                                                                                                               |
-| Mozilla Firefox             | 3.0.0.6+                      | Yes                | Yes                 | Yes (see [13](http://manicode.blogspot.com/2009/02/firefox-3006-httponly-champion.html))                                                                                                          |
-| Netscape Navigator          | 9.0b3                         | Yes                | Yes                 | No                                                                                                                                                                                                |
-| Opera                       | 9.23                          | No                 | No                  | No                                                                                                                                                                                                |
-| Opera                       | 9.50                          | Yes                | No                  | No                                                                                                                                                                                                |
-| Opera                       | 11                            | Yes                | Unknown             | Yes                                                                                                                                                                                               |
-| Safari                      | 3.0                           | No                 | No                  | No (almost yes, see [14](https://bugs.webkit.org/show_bug.cgi?id=10957))                                                                                                                          |
-| Safari                      | 5                             | Yes                | Yes                 | Yes                                                                                                                                                                                               |
-| iPhone (Safari)             | iOS 4                         | Yes                | Yes                 | Yes                                                                                                                                                                                               |
-| Google's Chrome             | Beta (initial public release) | Yes                | No                  | No (almost yes, see [15](https://bugs.webkit.org/show_bug.cgi?id=10957))                                                                                                                          |
-| Google's Chrome             | 12                            | Yes                | Yes                 | Yes                                                                                                                                                                                               |
-| Android                     | Android 2.3                   | Unknown            | Unknown             | No                                                                                                                                                                                                |
-
-**Table 1:** Browsers Supporting HttpOnly
-
-\* An attacker could still read the session cookie in a response to an
-\*\*[XmlHttpRequest](http://ha.ckers.org/blog/20070719/firefox-implements-httponly-and-is-vulnerable-to-xmlhttprequest/).
-
-As of 2011, 99% of browsers and most web application frameworks support
-HttpOnly\[1\].
-
-## Using WebGoat to Test for HttpOnly Support
-
-The goal of this section is to provide a step-by-step example of testing
-your browser for HttpOnly support.
-
-### WARNING
-
-The OWASP WEBGOAT HttpOnly lab is broken and does not show IE 8 Beta 2
-with ms08-069 as complete in terms of HttpOnly XMLHTTPRequest header
-leakage protection. This error is being tracked via
-[Issue 18](http://code.google.com/p/webgoat/issues/detail?id=18).
-
-### Getting Started
-
-![Click_link.JPG](../assets/images/Click_link.JPG)
-
-Assuming you have installed and launched WebGoat, begin by navigating to
-the **‘HttpOnly Test’ lesson** located within the Cross-Site Scripting
-(**XSS**) category. After loading the ‘HttpOnly Test’ lesson, as shown
-in **figure 1**, you are now able to begin testing web browsers
-supporting HttpOnly.
-
-### Lesson Goal
-
-If the *HttpOnly flag* is set, then your browser should not allow a
-client-side script to access the session cookie. Unfortunately, since
-the attribute is relatively new, several browsers may neglect to handle
-the new attribute properly.
-
-The **purpose** of this lesson is to test whether your browser supports
-the **HttpOnly cookie flag**. *Note the value of the* ***unique2u
-cookie***. If your browser supports HttpOnly, and you *enable* it for a
-cookie, a client-side script should NOT be able to read OR write to that
-cookie, but the browser can still send its value to the server. However,
-some browsers only prevent client side read access, but do not prevent
-write access.
-
-### Testing Web Browsers for HttpOnly Support
-
-The following test was performed on two browsers, **Internet Explorer
-7** and **Opera 9.22**, to demonstrate the results when the HttpOnly
-flag is enforced properly. As you will see, IE7 properly enforces the
-HttpOnly flag, whereas Opera does not properly enforce the HttpOnly
-flag.
-
-##### Disabling HttpOnly
-
-1) Select the option to **turn HttpOnly off** as shown below in **Figure 2**.
-
-![Fig2-Disabling_HTTPOnly.PNG](../assets/images/Fig2-Disabling_HTTPOnly.PNG)
-
-2) After turning HttpOnly off, select the **“Read Cookie”** button.
-
-- An alert dialog box will display on the screen notifying you that
-*since HttpOnly was not enabled*, the **‘unique2u’ cookie** was
-successfully read as shown below in **figure 3**.
-
-![Fig3-Read_HTTPOnly_Off.PNG](../assets/images/Fig3-Read_HTTPOnly_Off.PNG)
-
-3) With HttpOnly remaining disabled, select the **“Write Cookie”** button.
-
-- An alert dialog box will display on the screen notifying you that
-*since HttpOnly was not enabled*, the **‘unique2u’ cookie** was
-successfully modified on the client side as shown below in **figure
-4**.
-
-![Fig4-Write_HTTPOnly_Off.PNG](../assets/images/Fig4-Write_HTTPOnly_Off.PNG)
-
-- As you have seen thus far, **browsing without HttpOnly** on is a
-potential ***threat***. Next, we will **enable HttpOnly** to
-demonstrate how this flag protects the cookie.
-
-##### Enabling HttpOnly
-
-4) Select the *radio button* to enable HttpOnly as shown below in **figure 5**.
-
-![Fig5-Turning_HTTPOnly_On.PNG](../assets/images/Fig5-Turning_HTTPOnly_On.PNG)
-
-5) After enabling HttpOnly, select the **"Read Cookie"** button.
-
-- If the browser enforces the HttpOnly flag properly, an alert dialog
-box will display only the session ID rather than the contents of the
-**‘unique2u’ cookie** as shown below in **figure 6**.
-
-![Fig6-Cookie_Read_Protection.PNG](../assets/images/Fig6-Cookie_Read_Protection.PNG)
-
-- However, if the browser does not enforce the HttpOnly flag properly,
-an alert dialog box will display both the **‘unique2u’ cookie** and
-session ID as shown below in **figure 7**.
-
-![Fig7-No_Cookie_Read_Protection.PNG](../assets/images/Fig7-No_Cookie_Read_Protection.PNG)
-
-- Finally, we will test if the browser allows **write access** to the
-cookie with HttpOnly enabled.
-
-6) Select the **"Write Cookie"** button.
-
-- If the browser enforces the HttpOnly flag properly, client side
-modification will be unsuccessful in writing to the **‘unique2u’
-cookie** and an alert dialog box will display only containing the
-session ID as shown below in **figure 8**.
-
-![Fig6-Cookie_Read_Protection.PNG](../assets/images/Fig6-Cookie_Read_Protection.PNG)
-
-- However, if the browser does not enforce the write protection
-property of HttpOnly flag for the **‘unique2u’ cookie**, the cookie
-will be successfully modified to *HACKED* on the client side as
-shown below in **figure 9**.
-
-![Fig9-No_Cookie_Write_Protection.PNG](../assets/images/Fig9-No_Cookie_Write_Protection.PNG)
 
 ## References
 


### PR DESCRIPTION
Hi @kingthorin 👋  
I’ve opened a PR that removes obsolete browser references and the legacy
WebGoat HttpOnly testing content from `HttpOnly.md`.

This is a small, incremental update. Happy to follow up with additional
PRs if this approach looks good.
