### PR TITLE
Improve `Forced browsing` Example

### DIFF
--- a/pages/attacks/Forced_browsing.md
+++ b/pages/attacks/Forced_browsing.md
@@ -45,7 +45,7 @@ on-line agenda through the following URL:
 `www.site-example.com/users/calendar.php/user1/20070715`
 
 In the URL, it is possible to identify the username (`user1`) and
-the date (`yyyy/mm/dd`). If the user attempts to make a forced browsing
+the date (`yyyymmdd`). If the user attempts to make a forced browsing
 attack, they could access another user's agenda by predicting user
 identification and date, as follows:
 


### PR DESCRIPTION
Looking at the [examples of Forced browsing](https://owasp.org/www-community/attacks/Forced_browsing#examples) The date format `(mm/dd/yyyy)` is wrong. The URL uses `(yyyy/mm/dd)`.

Furthermore the following sentence was confusing:

```md
If the user attempts to make a forced browsing attack, they could `guess` another user’s agenda
```

The attacker actually `accesses` the users agenda by `guessing` the URL.

I also felt like the enumeration of unlinked contents that can be accessed could be improved.
