### PR TITLE
Add cloud-audit to Free for Open Source Application Security Tools

### DIFF
--- a/_data/tools.json
+++ b/_data/tools.json
@@ -452,6 +452,17 @@
 		]
 	},
 	{
+		"title": "cloud-audit",
+		"url": "https://github.com/gebalamariusz/cloud-audit",
+		"owner": "HAIT",
+		"license": "Open Source",
+		"platforms": "Windows, Linux, MacOS",
+		"note": "Open-source AWS security scanner that detects attack chains and generates remediation code (Terraform and CLI). 80 checks, CIS AWS v3.0, SOC 2 Type II compliance.",
+		"type": [
+			"DAST"
+		]
+	},
+	{
 		"title": "CloudDefense",
 		"url": "https://clouddefense.ai",
 		"owner": "CloudDefense",

--- a/_data/tools.json
+++ b/_data/tools.json
@@ -459,7 +459,7 @@
 		"platforms": "Windows, Linux, MacOS",
 		"note": "Open-source AWS security scanner that detects attack chains and generates remediation code (Terraform and CLI). 80 checks, CIS AWS v3.0, SOC 2 Type II compliance.",
 		"type": [
-			"DAST"
+			"SAST"
 		]
 	},
 	{

--- a/_data/tools.json
+++ b/_data/tools.json
@@ -452,17 +452,6 @@
 		]
 	},
 	{
-		"title": "cloud-audit",
-		"url": "https://github.com/gebalamariusz/cloud-audit",
-		"owner": "HAIT",
-		"license": "Open Source",
-		"platforms": "Windows, Linux, MacOS",
-		"note": "Open-source AWS security scanner that detects attack chains and generates remediation code (Terraform and CLI). 80 checks, CIS AWS v3.0, SOC 2 Type II compliance.",
-		"type": [
-			"SAST"
-		]
-	},
-	{
 		"title": "CloudDefense",
 		"url": "https://clouddefense.ai",
 		"owner": "CloudDefense",

--- a/pages/Free_for_Open_Source_Application_Security_Tools.md
+++ b/pages/Free_for_Open_Source_Application_Security_Tools.md
@@ -322,6 +322,9 @@ open source projects also consider using good code quality tools. A few that we 
   - [AWS Firewall Factory](https://github.com/globaldatanet/aws-firewall-factory) - An open source solution that makes it easy to deploy, update, and provision OWASP TOP 10 compliant web application firewalls (WAFs) at scale while centrally managing them with AWS Firewall Manager. This solution streamlines security management by enabling customisation of WAF configurations and adherence to AWS best practices.
   - [DSSRF](https://github.com/HackingRepo/dssrf-js) - dssrf Defend Against SSRF attacks by providing huge of utils for validation, you integrate it with your web client before making request you validate the url for eliminating SSRF attacks.
 
+### Cloud Security Tools
+  - [cloud-audit](https://github.com/gebalamariusz/cloud-audit) - An open-source (MIT) AWS security scanner that runs 94 checks across 23 AWS services, detects attack chains across misconfigurations, and generates remediation code (Terraform HCL and AWS CLI) for every finding. Supports CIS AWS Foundations Benchmark v3.0 and SOC 2 Type II compliance frameworks. Available on [PyPI](https://pypi.org/project/cloud-audit/), [Docker](https://github.com/gebalamariusz/cloud-audit/pkgs/container/cloud-audit), and as a [GitHub Action](https://github.com/gebalamariusz/cloud-audit). Free and open source for all use.
+
 ### Security Tools Built into DevOps/CI Environments
   - GitLab - is building security into their platform and it is quickly evolving [as described here](https://about.gitlab.com/direction/secure/#security-paradigm).
       - They are leveraging the best free open source tools they can find


### PR DESCRIPTION
## Summary

Add [cloud-audit](https://github.com/gebalamariusz/cloud-audit) to the **Free for Open Source Application Security Tools** page under a new **Cloud Security Tools** category.

Per reviewer feedback, cloud-audit is a cloud security posture scanner — not a DAST or SAST tool — so it belongs on this page rather than in `_data/tools.json`.

**cloud-audit** is an open-source (MIT) AWS security scanner that:
- Runs 94 security checks across 23 AWS services
- Detects attack chains across misconfigurations
- Generates remediation code (Terraform HCL + AWS CLI) for every finding
- Supports CIS AWS Foundations Benchmark v3.0 and SOC 2 Type II compliance
- Available on PyPI, Docker (GHCR), and as a GitHub Action

GitHub: https://github.com/gebalamariusz/cloud-audit