### PR TITLE
Add ansible-security-scanner to Source Code Analysis Tools

### DIFF
--- a/_data/tools.json
+++ b/_data/tools.json
@@ -110,6 +110,17 @@
 		]
 	},
 	{
+		"title": "ansible-security-scanner",
+		"url": "https://github.com/cpeoples/ansible-security-scanner",
+		"owner": null,
+		"license": "Open Source or Free",
+		"platforms": "CLI, CI/CD integration",
+		"note": "Static analyzer for Ansible playbooks, roles, and collections. Detects hardcoded credentials, command and template injection, RCE, and supply-chain risks. Outputs SARIF, CycloneDX SBOM, GitLab SAST, JUnit, JSON, and Markdown.",
+		"type": [
+			"SAST"
+		]
+	},
+	{
 		"title": "API Scanning",
 		"url": "https://www.indusface.com/api-scanning-listing.php",
 		"owner": "Indusface",


### PR DESCRIPTION
Adds ansible-security-scanner to the SAST tools list. It's a static analyzer for Ansible playbooks, roles, and collections that detects hardcoded credentials, command/template injection, RCE, and supply-chain risks, with SARIF, CycloneDX SBOM, and GitLab SAST output.

Source: https://github.com/cpeoples/ansible-security-scanner