### PR TITLE
Add AutoSecT (Kratikal) to DAST tools list

### DIFF
--- a/_data/tools.json
+++ b/_data/tools.json
@@ -275,6 +275,17 @@
 		]
 	},
 	{
+		"title": "AutoSecT",
+		"url": "https://www.kratikal.com/autosect",
+		"owner": "Kratikal",
+		"license": "Commercial",
+		"platforms": "SaaS",
+		"note": "15 Days Free Trial",
+		"type": [
+			"DAST"
+		]
+	},
+	{
 		"title": "Automated Security Helper",
 		"url": "https://github.com/aws-samples/automated-security-helper",
 		"owner": "AWS",


### PR DESCRIPTION
Adds AutoSecT by Kratikal, a SaaS-based VAPT platform providing dynamic vulnerability scanning for web applications, APIs, cloud, and networks. Inserted in alphabetical order between Astrée and Automated Security Helper.