### PR TITLE
Add AutoSecT (Kratikal) to DAST tools list

### DIFF
--- a/_data/tools.json
+++ b/_data/tools.json
@@ -286,6 +286,17 @@
 		]
 	},
 	{
+		"title": "AutoSecT",
+		"url": "https://www.kratikal.com/autosect",
+		"owner": "Kratikal",
+		"license": "Commercial",
+		"platforms": "SaaS",
+		"note": "15 Days Free Trial",
+		"type": [
+			"DAST"
+		]
+	},
+	{
 		"title": "Bandit",
 		"url": "https://github.com/PyCQA/bandit",
 		"owner": null,


### PR DESCRIPTION
Adds AutoSecT by Kratikal, a SaaS-based VAPT platform providing dynamic vulnerability scanning for web applications, APIs, cloud, and networks. Inserted in alphabetical order between Automated Security Helper and Bandit.