### PR TITLE
Added more details about Catch NullPointerException page

### DIFF
--- a/pages/vulnerabilities/Catch_NullPointerException.md
+++ b/pages/vulnerabilities/Catch_NullPointerException.md
@@ -2,8 +2,8 @@
 
 layout: col-sidebar
 title: Catch NullPointerException
-author:
-contributors:
+author: 
+contributors: Abdullah Al-Khalaf
 permalink: /vulnerabilities/Catch_NullPointerException
 tags: vulnerability, Catch NullPointerException
 
@@ -17,7 +17,7 @@ tags: vulnerability, Catch NullPointerException
 
 ## Description
 
-It is generally a bad practice to catch NullPointerException.
+Catching NullPointerException (NPE) by using a `try`-`catch` statement is a bad practice. It should be avoided whenever possible because catching an NPE creates a new object, which consumes more memory than alternative methods.
 
 Programmers typically catch NullPointerException under three circumstances:
 
@@ -33,17 +33,29 @@ TBD
 
 ## Examples
 
-The following code mistakenly catches a NullPointerException.
+The following code is what a programmer might mistakenly do and should avoid (this is an oversimplified example).
 
 ```
 try {
-  mysteryMethod();
+		UserSession user = Server.Session.getUserLoginSession();
+		Server.sendText("Hello "+ user.getName());
 } catch (NullPointerException npe) {
-  ...
+		Server.sendText("Please login")
+}
+```
+
+The following code is a better alternative that uses an `if` statement and avoids creating an NPE object.
+```
+UserSession user = Server.Session.getUserLoginSession();
+if(user != null){
+		Server.sendText("Hello "+ user.getName());
+} else {
+		Server.sendText("Please login")
 }
 ```
 
 ## Related [Attacks](../attacks/)
+* [Denial of Service](https://owasp.org/www-community/attacks/Denial_of_Service): Creating NPE object requires computing power and memory
 
 ## Related [Vulnerabilities](../vulnerabilities/)
 
@@ -51,7 +63,5 @@ try {
 
 ## References
 
-Note: A reference to related [CWE](http://cwe.mitre.org/) or [CAPEC](http://capec.mitre.org/) article should be added when exists.
-Eg:
+- [CWE-395](https://cwe.mitre.org/data/definitions/395.html).
 
-- [CWE 79](http://cwe.mitre.org/data/definitions/79.html).


### PR DESCRIPTION
I am new to the OWASP community, so excuse me if there are mistakes here and there (especially whether I should list my name as Contributor, Author, or neither). 
Also, I think there is already plagiarism on the page (from "Programmers typically...." to ".....is acceptable"), as seen in [CWE-395](https://cwe.mitre.org/data/definitions/395.html); it's copy-pasted.
