### PR TITLE
Add Vigolium - DAST

### DIFF
--- a/_data/tools.json
+++ b/_data/tools.json
@@ -2422,6 +2422,17 @@
 		]
 	},
 	{
+		"title": "Vigolium",
+		"url": "https://github.com/vigolium/vigolium",
+		"owner": "j3ssie",
+		"license": "Open Source",
+		"platforms": "Unix/Linux, and Macintosh",
+		"note": "Vigolium is High-fidelity vulnerability scanner fusing agentic AI with native speed, modularity, and precision",
+		"type": [
+			"DAST"
+		]
+	},
+	{
 		"title": "VisualCodeGrepper (VCG)",
 		"url": "https://sourceforge.net/projects/visualcodegrepp/",
 		"owner": null,


### PR DESCRIPTION
Adds **Vigolium**, a DAST tool, to `_data/tools.json`.

Vigolium is a high-fidelity vulnerability scanner fusing agentic AI with native speed, modularity, and precision.

- **URL:** https://github.com/vigolium/vigolium
- **Owner:** j3ssie
- **License:** Open Source
- **Platforms:** Unix/Linux, and Macintosh
- **Type:** DAST

The entry is inserted in alphabetical order by title (between `Vex` and `VisualCodeGrepper (VCG)`).