### PR TITLE
Add Penetrify to Vulnerability Scanning Tools (Commercial section)

### DIFF
--- a/_data/tools.json
+++ b/_data/tools.json
@@ -1640,17 +1640,17 @@
 			"SAST"
 		]
 	},
-        {
-                "title": "Penetrify.cloud",
-                "url": "https://www.penetrify.cloud",
-                "owner": "Penetrify.cloud",
-                "license": "Commercial or Free",
-                "platforms": "SaaS",
-                "note": "Autonomous AI penetration testing for web applications and APIs. Runs in CI/CD pipelines and reports OWASP Top 10 and other vulnerability classes with reproduction steps. Free trial available.",
-                "type": [
-                        "DAST"
-                ]
-        },
+		{
+			"title": "Penetrify.cloud",
+			"url": "https://www.penetrify.cloud",
+			"owner": "Penetrify.cloud",
+			"license": "Commercial or Free",
+			"platforms": "SaaS",
+			"note": "Autonomous AI penetration testing for web applications and APIs. Runs in CI/CD pipelines and reports OWASP Top 10 and other vulnerability classes with reproduction steps. Free trial available.",
+			"type": [
+				"DAST"
+			]
+		},
 	{
 		"title": "Pentest-Tools.com Website Scanner",
 		"url": "https://pentest-tools.com/website-vulnerability-scanning/website-scanner",

--- a/_data/tools.json
+++ b/_data/tools.json
@@ -1640,17 +1640,17 @@
 			"SAST"
 		]
 	},
-		{
-			"title": "Penetrify.cloud",
-			"url": "https://www.penetrify.cloud",
-			"owner": "Penetrify.cloud",
-			"license": "Commercial or Free",
-			"platforms": "SaaS",
-			"note": "Autonomous AI penetration testing for web applications and APIs. Runs in CI/CD pipelines and reports OWASP Top 10 and other vulnerability classes with reproduction steps. Free trial available.",
-			"type": [
-				"DAST"
-			]
-		},
+	{
+		"title": "Penetrify.cloud",
+		"url": "https://www.penetrify.cloud",
+		"owner": "Penetrify.cloud",
+		"license": "Commercial or Free",
+		"platforms": "SaaS",
+		"note": "Autonomous AI penetration testing for web applications and APIs. Runs in CI/CD pipelines and reports OWASP Top 10 and other vulnerability classes with reproduction steps. Free trial available.",
+		"type": [
+			"DAST"
+		]
+	},
 	{
 		"title": "Pentest-Tools.com Website Scanner",
 		"url": "https://pentest-tools.com/website-vulnerability-scanning/website-scanner",

--- a/_data/tools.json
+++ b/_data/tools.json
@@ -1640,6 +1640,17 @@
 			"SAST"
 		]
 	},
+        {
+                "title": "Penetrify.cloud",
+                "url": "https://www.penetrify.cloud",
+                "owner": "Penetrify.cloud",
+                "license": "Commercial or Free",
+                "platforms": "SaaS",
+                "note": "Autonomous AI penetration testing for web applications and APIs. Runs in CI/CD pipelines and reports OWASP Top 10 and other vulnerability classes with reproduction steps. Free trial available.",
+                "type": [
+                        "DAST"
+                ]
+        },
 	{
 		"title": "Pentest-Tools.com Website Scanner",
 		"url": "https://pentest-tools.com/website-vulnerability-scanning/website-scanner",


### PR DESCRIPTION
Adds Penetrify to the Commercial section of the Vulnerability Scanning Tools list.

What it is: an autonomous AI penetration testing platform for web applications and APIs. It maps the attack surface, tests authentication/authorization, and reports OWASP Top 10 and other vulnerability classes with reproduction steps; integrates with CI/CD (GitHub Actions, GitLab CI). Web/SaaS, commercial with a free trial.

Placement: inserted alphabetically in the Commercial subsection, matching the existing entry format.

Disclosure: I'm affiliated with Penetrify. I've kept the description neutral and factual to match the page's tone - happy to adjust wording or remove any promotional phrasing if a maintainer prefers.