### PR TITLE
Fix IPASIS free-tier figure in api-tools.yml (100 req/day → 3,000 req/month)

### DIFF
--- a/_data/api-tools.yml
+++ b/_data/api-tools.yml
@@ -287,7 +287,7 @@
   posture: "https://img.shields.io/badge/API_Posture-No-red.svg"
   runtime: "https://img.shields.io/badge/API_Runtime-Yes-brightgreen.svg"
   testing: "https://img.shields.io/badge/API_Testing-No-red.svg"
-  notes: "Real-time bot detection and fraud prevention API. Combines IP reputation, VPN/proxy/Tor detection, and email validation in a single call. Returns an Interaction Trust Score (0-100). Sub-20ms response. Free tier: 100 req/day."
+  notes: "Real-time bot detection and fraud prevention API. Combines IP reputation, VPN/proxy/Tor detection, and email validation in a single call. Returns an Interaction Trust Score (0-100). Sub-20ms response. Free tier: 3,000 req/month."
 - name: "Insomnia"
   link: "https://insomnia.rest/"
   from: "Kong"


### PR DESCRIPTION
## What
One-line correction to the existing IPASIS entry in `_data/api-tools.yml` (added in #1280). The `notes` field currently states "Free tier: 100 req/day", which is inaccurate — the actual free tier is **3,000 requests/month**.

## Why
The figure was wrong at the time the entry was added. This corrects the only inaccurate field so the listing reflects the real free-tier limit. No other fields changed.

## Disclosure
I'm affiliated with IPASIS — submitting this purely to correct factual data on our own already-merged listing, not to add a new entry.