### PR TITLE
Update BomLens link to renamed repository (sktelecom/bomlens)

### DIFF
--- a/pages/Free_for_Open_Source_Application_Security_Tools.md
+++ b/pages/Free_for_Open_Source_Application_Security_Tools.md
@@ -195,7 +195,7 @@ Free tools of this type:
      - Identifies, fixes and prevents known vulnerabilities. Read more at [https://debricked.com](https://debricked.com)
      - [Create a free account](https://app.debricked.com/en/register)
    - [retire.js](https://github.com/RetireJS/retire.js): free open source tool for finding javascript libraries with known vulnerabilities. Originally a command line tool, and there are plugins for browsers and scanners.
-  - [BomLens](https://github.com/sktelecom/sbom-tools): free open source (Apache-2.0)
+  - [BomLens](https://github.com/sktelecom/bomlens): free open source (Apache-2.0)
     tool that generates a CycloneDX SBOM from source code, containers, binaries,
     firmware, or AI models, and reports known vulnerable components and license
     risks. Runs locally in Docker with a CLI, web UI, and desktop app.


### PR DESCRIPTION
The BomLens repository was renamed from `sktelecom/sbom-tools` to `sktelecom/bomlens`. This updates the link on the Free/Open Source tools page to the new path. The old URL still 301-redirects, but the direct link is clearer.