### PR TITLE
Add OpenTaint to SAST tools

### DIFF
--- a/_data/tools.json
+++ b/_data/tools.json
@@ -1531,6 +1531,17 @@
 		]
 	},
 	{
+		"title": "OpenTaint",
+		"url": "https://github.com/seqra/opentaint",
+		"owner": "Seqra",
+		"license": "Open Source",
+		"platforms": null,
+		"note": "Open source taint analysis engine designed to work with AI agents. During a security review, the agent enacts what it learns: vulnerability patterns as taint rules forbidding classes of dataflow traces, and code behavior as summaries letting the engine see through code it never analyzed. The engine itself is built to hold all three corners of the classic trilemma — scan time, false alarms, missed findings — tracking traces across procedures, fields, and aliases at scale. Learning is expensive and unpredictable, searching cheap and deterministic — so the agent learns the code on demand, the engine searches it on every scan, and the security review becomes lean and continuous.",
+		"type": [
+			"SAST"
+		]
+	},
+	{
 		"title": "OpenVAS by Greenbone",
 		"url": "https://github.com/greenbone/openvas-scanner",
 		"owner": "greenbone",


### PR DESCRIPTION
Adds OpenTaint to the SAST tools. OpenTaint is an open-source taint-analysis engine designed to work with AI agents, tracking untrusted data across procedures, fields, and aliases to find dataflow vulnerabilities.