### PR TITLE
Add Zennoxa Shield (open-source SAST/SCA) to tools list

### DIFF
--- a/_data/tools.json
+++ b/_data/tools.json
@@ -2710,6 +2710,18 @@
 		]
 	},
 	{
+		"title": "Zennoxa Shield",
+		"url": "https://zennoxa.com",
+		"owner": "Zennoxa",
+		"license": "Open Source or Free",
+		"platforms": "CLI (macOS, Linux, Windows), CI/CD",
+		"note": "Open-source (MIT) developer-first scanner. One offline pass runs SAST, dependency (SCA), secret, container and IaC checks across 24 languages, then ranks findings by whether the vulnerable code is reachable. Emits SARIF and a CycloneDX/SPDX SBOM.",
+		"type": [
+			"SAST",
+			"SCA"
+		]
+	},
+	{
 		"title": "ZeroPath",
 		"url": "https://zeropath.com/",
 		"owner": "ZeroPath",


### PR DESCRIPTION
Adds **Zennoxa Shield** to `_data/tools.json` under SAST + SCA.

Zennoxa Shield is an open-source (MIT) developer-first code security scanner. One offline pass runs SAST, dependency (SCA), secret, container and IaC checks across 24 languages, then ranks findings by whether the vulnerable code is reachable. It emits SARIF and a CycloneDX/SPDX SBOM. Free for open-source use.

- Repository: https://github.com/Zennoxa/shield
- Site: https://zennoxa.com
- Reproducible OWASP Benchmark result: https://github.com/Zennoxa/shield/blob/main/bench/owasp/benchmark.json

The entry follows the existing schema and is inserted alphabetically (single object, no reformatting of the rest of the file).
