### PR TITLE
fix(ci): Fix slow CI validation and a couple of bugs in the check scripts

### DIFF
--- a/.github/workflows/scripts/check_duplicates.py
+++ b/.github/workflows/scripts/check_duplicates.py
@@ -13,6 +13,7 @@ import json
 import sys
 import re
 from collections import defaultdict
+from urllib.parse import urlsplit, urlunsplit
 
 
 def normalize_title(title):
@@ -40,16 +41,27 @@ def normalize_url(url):
     """
     Normalize URL for duplicate detection.
     - Remove trailing slashes
-    - Convert to lowercase (domain is case-insensitive)
+    - Convert scheme and host/domain to lowercase (scheme and domain are case-insensitive)
     
     This helps detect URLs like:
     - "https://example.com/" vs "https://example.com"
+    - "HTTPS://EXAMPLE.COM/path" vs "https://example.com/path"
     """
     if not url:
         return ""
     # Remove trailing slash
-    normalized = url.rstrip('/')
-    return normalized
+    trimmed = url.rstrip('/')
+    try:
+        parsed = urlsplit(trimmed)
+        return urlunsplit((
+            parsed.scheme.lower(),
+            parsed.netloc.lower(),
+            parsed.path,
+            parsed.query,
+            parsed.fragment
+        ))
+    except Exception:
+        return trimmed
 
 
 def check_duplicates(json_file):

--- a/.github/workflows/scripts/check_duplicates.py
+++ b/.github/workflows/scripts/check_duplicates.py
@@ -3,11 +3,12 @@
 Check if tools.json contains duplicate entries.
 Detects duplicates by:
 - Title (case-insensitive, normalized)
-- URL (normalized - trailing slashes removed)
+- URL (normalized - trailing slashes removed, scheme and host lowercased)
 
 Normalization helps detect similar entries like:
 - "FindSecBugs" vs "Find Security Bugs"
 - "https://example.com/" vs "https://example.com"
+- "HTTPS://EXAMPLE.COM/path" vs "https://example.com/path"
 """
 import json
 import sys
@@ -122,7 +123,7 @@ def check_duplicates(json_file):
         # Check for duplicate URLs (normalized)
         duplicate_urls = {norm: entries for norm, entries in normalized_urls_map.items() if len(entries) > 1}
         if duplicate_urls:
-            print("ERROR: Found duplicate URLs (normalized - trailing slashes removed)\n")
+            print("ERROR: Found duplicate URLs (normalized - trailing slashes removed, scheme and host lowercased)\n")
             for normalized, entries in sorted(duplicate_urls.items()):
                 # Check if all URLs are exactly the same or just normalized-same
                 original_urls = set(url for _, url in entries)
@@ -130,7 +131,7 @@ def check_duplicates(json_file):
                     print(f"Exact duplicate URL '{entries[0][1]}' appears {len(entries)} times:")
                 else:
                     urls_list = ', '.join(f"'{url}'" for _, url in entries)
-                    print(f"Similar URLs detected (differ only in trailing slashes):")
+                    print(f"Similar URLs detected (normalized to the same URL):")
                     print(f"  Variations: {urls_list}")
                 
                 for idx, original_url in entries:

--- a/.github/workflows/scripts/check_editorconfig.py
+++ b/.github/workflows/scripts/check_editorconfig.py
@@ -50,23 +50,12 @@ def check_json_structural_indentation(text, lines):
         
         # Track which entry we're in based on depth
         # At depth 1, we're inside a top-level array entry
-        if is_array and depth == 1:
-            # Check if this line starts a new entry (opening brace at depth 1)
-            if stripped == '{' or stripped.startswith('{'):
-                # We're entering a new entry - count how many entries we've seen
-                # by counting previous opening braces at this depth
-                entry_count = 0
-                for prev_i in range(i - 1, 0, -1):
-                    prev_line = lines[prev_i - 1].strip()
-                    # Count opening braces that would be at depth 1
-                    if len(lines[prev_i - 1]) > 0 and lines[prev_i - 1][0] == '\t':
-                        if not lines[prev_i - 1].startswith('\t\t'):
-                            if prev_line == '{' or prev_line.startswith('{'):
-                                entry_count += 1
-                
-                current_entry_index = entry_count
-                if current_entry_index < len(data):
-                    current_entry_title = data[current_entry_index].get('title')
+        if is_array and depth == 1 and (stripped == '{' or stripped.startswith('{')):
+            current_entry_index = 0 if current_entry_index is None else current_entry_index + 1
+            if current_entry_index < len(data):
+                current_entry_title = data[current_entry_index].get('title')
+            else:
+                current_entry_title = None
         elif depth == 0:
             # Outside of any entry
             current_entry_index = None
@@ -185,33 +174,86 @@ def check_unicode_escapes(text, data):
     
     # Common Unicode escape patterns for Latin characters with diacritics (U+0000 to U+00FF)
     # These should be written directly, not escaped
-    # Note: Using \\u00XX pattern to specifically target Latin-1 characters
-    # which are commonly unnecessarily escaped (e.g., \\u00e7 for ç)
     unicode_escape_pattern = re.compile(r'\\u00[0-9a-fA-F]{2}')
     
     # Find all Unicode escape sequences - only proceed if any are found
     if not unicode_escape_pattern.search(text):
         return errors
     
-    # Try to identify which entries contain these escapes
-    if isinstance(data, list):
-        for entry_index, entry in enumerate(data):
-            entry_title = entry.get('title', 'Unknown')
-            # Find specific fields with escapes
-            fields_with_escapes = []
-            for key, value in entry.items():
-                if isinstance(value, str):
-                    # Only serialize to check for escapes if the value might contain them
-                    value_json = json.dumps(value, ensure_ascii=True)
-                    if unicode_escape_pattern.search(value_json):
-                        fields_with_escapes.append(key)
+    lines = text.split('\n')
+    depth = 0
+    in_string = False
+    escape_next = False
+    current_entry_index = None
+    current_entry_title = None
+    is_array = isinstance(data, list)
+    field_name_pattern = re.compile(r'^\s*"([^"]+)"\s*:')
+    
+    for i, line in enumerate(lines, 1):
+        if i == len(lines) and line == '':
+            continue
+        
+        stripped = line.strip()
+        if not stripped:
+            continue
+        
+        if is_array and depth == 1 and (stripped == '{' or stripped.startswith('{')):
+            current_entry_index = 0 if current_entry_index is None else current_entry_index + 1
+            if current_entry_index < len(data):
+                current_entry_title = data[current_entry_index].get('title')
+            else:
+                current_entry_title = None
+        elif depth == 0:
+            current_entry_index = None
+            current_entry_title = None
+        
+        if unicode_escape_pattern.search(line):
+            field_match = field_name_pattern.match(line)
+            field_name = field_match.group(1) if field_match else "unknown"
             
-            if fields_with_escapes:
+            if current_entry_index is not None and current_entry_title:
                 errors.append(
-                    f"ERROR: Entry #{entry_index} ('{entry_title}'): "
-                    f"Contains Unicode escape sequences in field(s): {', '.join(fields_with_escapes)}. "
+                    f"ERROR: Entry #{current_entry_index} ('{current_entry_title}'): "
+                    f"Line {i} contains Unicode escape sequences in field '{field_name}'. "
                     f"Use ensure_ascii=False in json.dump() to preserve special characters."
                 )
+            elif current_entry_index is not None:
+                errors.append(
+                    f"ERROR: Entry #{current_entry_index}: "
+                    f"Line {i} contains Unicode escape sequences in field '{field_name}'. "
+                    f"Use ensure_ascii=False in json.dump() to preserve special characters."
+                )
+            else:
+                errors.append(
+                    f"ERROR: Line {i} contains Unicode escape sequences. "
+                    f"Use ensure_ascii=False in json.dump() to preserve special characters."
+                )
+        
+        # Update depth
+        line_in_string = in_string
+        line_escape_next = escape_next
+        open_count = 0
+        close_count = 0
+        for char in stripped:
+            if line_escape_next:
+                line_escape_next = False
+                continue
+            if char == '\\':
+                line_escape_next = True
+                continue
+            if char == '"':
+                line_in_string = not line_in_string
+                continue
+            if not line_in_string:
+                if char == '{' or char == '[':
+                    open_count += 1
+                elif char == '}' or char == ']':
+                    close_count += 1
+        in_string = line_in_string
+        escape_next = line_escape_next
+        depth += (open_count - close_count)
+        if depth < 0:
+            depth = 0
     
     return errors
 
@@ -255,6 +297,8 @@ def check_editorconfig(json_file):
         
         # Track current entry while checking each line
         depth = 0
+        in_string = False
+        escape_next = False
         current_entry_index = None
         current_entry_title = None
         
@@ -265,20 +309,13 @@ def check_editorconfig(json_file):
             
             stripped = line.strip()
             
-            # Track which entry we're in based on depth (similar to structural check)
-            if is_array and data and depth == 1:
-                if stripped == '{' or stripped.startswith('{'):
-                    # Count entries seen so far
-                    entry_count = 0
-                    for prev_i in range(i - 1, 0, -1):
-                        prev_line = lines[prev_i - 1].strip()
-                        if len(lines[prev_i - 1]) > 0 and lines[prev_i - 1][0] == '\t':
-                            if not lines[prev_i - 1].startswith('\t\t'):
-                                if prev_line == '{' or prev_line.startswith('{'):
-                                    entry_count += 1
-                    current_entry_index = entry_count
-                    if current_entry_index < len(data):
-                        current_entry_title = data[current_entry_index].get('title')
+            # Track which entry we're in based on depth
+            if is_array and data and depth == 1 and (stripped == '{' or stripped.startswith('{')):
+                current_entry_index = 0 if current_entry_index is None else current_entry_index + 1
+                if current_entry_index < len(data):
+                    current_entry_title = data[current_entry_index].get('title')
+                else:
+                    current_entry_title = None
             elif depth == 0:
                 current_entry_index = None
                 current_entry_title = None
@@ -304,8 +341,33 @@ def check_editorconfig(json_file):
             # Update depth for entry tracking
             if not stripped:
                 continue
-            open_count = stripped.count('{') + stripped.count('[')
-            close_count = stripped.count('}') + stripped.count(']')
+            
+            line_in_string = in_string
+            line_escape_next = escape_next
+            open_count = 0
+            close_count = 0
+            
+            for char in stripped:
+                if line_escape_next:
+                    line_escape_next = False
+                    continue
+                
+                if char == '\\':
+                    line_escape_next = True
+                    continue
+                
+                if char == '"':
+                    line_in_string = not line_in_string
+                    continue
+                
+                if not line_in_string:
+                    if char == '{' or char == '[':
+                        open_count += 1
+                    elif char == '}' or char == ']':
+                        close_count += 1
+            
+            in_string = line_in_string
+            escape_next = line_escape_next
             depth += (open_count - close_count)
             if depth < 0:
                 depth = 0

--- a/.github/workflows/scripts/check_editorconfig.py
+++ b/.github/workflows/scripts/check_editorconfig.py
@@ -14,6 +14,42 @@ import json
 import re
 
 
+def _update_depth(stripped, depth, in_string, escape_next):
+    """
+    Return the updated (depth, in_string, escape_next) after processing one
+    stripped line, counting only braces/brackets that appear outside strings.
+
+    This is the single source of truth for depth tracking used by all checks
+    in this module.
+    """
+    line_in_string = in_string
+    line_escape_next = escape_next
+    open_count = 0
+    close_count = 0
+
+    for char in stripped:
+        if line_escape_next:
+            line_escape_next = False
+            continue
+
+        if char == '\\':
+            line_escape_next = True
+            continue
+
+        if char == '"':
+            line_in_string = not line_in_string
+            continue
+
+        if not line_in_string:
+            if char == '{' or char == '[':
+                open_count += 1
+            elif char == '}' or char == ']':
+                close_count += 1
+
+    new_depth = max(0, depth + (open_count - close_count))
+    return new_depth, line_in_string, line_escape_next
+
+
 def check_json_structural_indentation(text, lines):
     """
     Check if JSON structural indentation adheres to tab-based rules.
@@ -21,7 +57,7 @@ def check_json_structural_indentation(text, lines):
     Uses JSON structure to identify which entry errors belong to.
     """
     errors = []
-    
+
     # Try to parse JSON to get entry information
     try:
         data = json.loads(text)
@@ -29,25 +65,25 @@ def check_json_structural_indentation(text, lines):
     except json.JSONDecodeError as e:
         errors.append(f"ERROR: Invalid JSON - {e}")
         return errors
-    
+
     # Track expected indentation depth and current entry
     depth = 0
     in_string = False
     escape_next = False
     current_entry_index = None
     current_entry_title = None
-    
+
     for i, line in enumerate(lines, 1):
         # Skip the final empty line
         if i == len(lines) and line == '':
             continue
-        
+
         stripped = line.strip()
-        
+
         # Skip empty lines
         if not stripped:
             continue
-        
+
         # Track which entry we're in based on depth
         # At depth 1, we're inside a top-level array entry
         if is_array and depth == 1 and (stripped == '{' or stripped.startswith('{')):
@@ -60,7 +96,7 @@ def check_json_structural_indentation(text, lines):
             # Outside of any entry
             current_entry_index = None
             current_entry_title = None
-        
+
         # Count leading tabs and check for mixed indentation
         leading_tabs = 0
         has_mixed_indentation = False
@@ -89,23 +125,23 @@ def check_json_structural_indentation(text, lines):
             else:
                 # First non-whitespace character
                 break
-        
+
         # Determine expected indentation based on the line content
         # Lines that decrease depth (closing braces/brackets)
         if stripped.startswith('}') or stripped.startswith(']'):
             expected_depth = depth - 1
         else:
             expected_depth = depth
-        
+
         # Guard against negative depth (malformed JSON structure)
         if expected_depth < 0:
             expected_depth = 0
-        
+
         # Check if indentation matches expected depth (skip if mixed indentation already reported)
         if not has_mixed_indentation and leading_tabs != expected_depth:
             # Get context for error message
             context = stripped[:50] + '...' if len(stripped) > 50 else stripped
-            
+
             # Use entry information from structural tracking
             if current_entry_index is not None and current_entry_title:
                 errors.append(
@@ -122,64 +158,29 @@ def check_json_structural_indentation(text, lines):
                     f"ERROR: Line {i} has incorrect indentation: "
                     f"expected {expected_depth} tab(s), found {leading_tabs} tab(s) - '{context}'"
                 )
-        
-        # Update depth for next line based on what's on this line
-        # We need to properly count braces/brackets, ignoring those in strings
-        line_in_string = in_string
-        line_escape_next = escape_next
-        open_count = 0
-        close_count = 0
-        
-        for char in stripped:
-            if line_escape_next:
-                line_escape_next = False
-                continue
-            
-            if char == '\\':
-                line_escape_next = True
-                continue
-            
-            if char == '"':
-                line_in_string = not line_in_string
-                continue
-            
-            if not line_in_string:
-                if char == '{' or char == '[':
-                    open_count += 1
-                elif char == '}' or char == ']':
-                    close_count += 1
-        
-        # Update the persistent string state for multi-line string support
-        in_string = line_in_string
-        escape_next = line_escape_next
-        
-        # Account for same-line open/close (like "[]" or "{}")
-        net_change = open_count - close_count
-        depth += net_change
-        
-        # Guard against negative depth
-        if depth < 0:
-            depth = 0
-    
+
+        # Update depth for the next line
+        depth, in_string, escape_next = _update_depth(stripped, depth, in_string, escape_next)
+
     return errors
 
 
 def check_unicode_escapes(text, data):
     """
     Check if JSON file contains unnecessary Unicode escape sequences.
-    Characters like ç, ê, etc. should be stored as-is, not as \u00e7, \u00ea.
+    Characters like ç, ê, etc. should be stored as-is, not as \\u00e7, \\u00ea.
     This requires ensure_ascii=False when using json.dump().
     """
     errors = []
-    
+
     # Common Unicode escape patterns for Latin characters with diacritics (U+0000 to U+00FF)
     # These should be written directly, not escaped
     unicode_escape_pattern = re.compile(r'\\u00[0-9a-fA-F]{2}')
-    
+
     # Find all Unicode escape sequences - only proceed if any are found
     if not unicode_escape_pattern.search(text):
         return errors
-    
+
     lines = text.split('\n')
     depth = 0
     in_string = False
@@ -188,15 +189,15 @@ def check_unicode_escapes(text, data):
     current_entry_title = None
     is_array = isinstance(data, list)
     field_name_pattern = re.compile(r'^\s*"([^"]+)"\s*:')
-    
+
     for i, line in enumerate(lines, 1):
         if i == len(lines) and line == '':
             continue
-        
+
         stripped = line.strip()
         if not stripped:
             continue
-        
+
         if is_array and depth == 1 and (stripped == '{' or stripped.startswith('{')):
             current_entry_index = 0 if current_entry_index is None else current_entry_index + 1
             if current_entry_index < len(data):
@@ -206,11 +207,11 @@ def check_unicode_escapes(text, data):
         elif depth == 0:
             current_entry_index = None
             current_entry_title = None
-        
+
         if unicode_escape_pattern.search(line):
             field_match = field_name_pattern.match(line)
             field_name = field_match.group(1) if field_match else "unknown"
-            
+
             if current_entry_index is not None and current_entry_title:
                 errors.append(
                     f"ERROR: Entry #{current_entry_index} ('{current_entry_title}'): "
@@ -228,44 +229,21 @@ def check_unicode_escapes(text, data):
                     f"ERROR: Line {i} contains Unicode escape sequences. "
                     f"Use ensure_ascii=False in json.dump() to preserve special characters."
                 )
-        
-        # Update depth
-        line_in_string = in_string
-        line_escape_next = escape_next
-        open_count = 0
-        close_count = 0
-        for char in stripped:
-            if line_escape_next:
-                line_escape_next = False
-                continue
-            if char == '\\':
-                line_escape_next = True
-                continue
-            if char == '"':
-                line_in_string = not line_in_string
-                continue
-            if not line_in_string:
-                if char == '{' or char == '[':
-                    open_count += 1
-                elif char == '}' or char == ']':
-                    close_count += 1
-        in_string = line_in_string
-        escape_next = line_escape_next
-        depth += (open_count - close_count)
-        if depth < 0:
-            depth = 0
-    
+
+        # Update depth for the next line
+        depth, in_string, escape_next = _update_depth(stripped, depth, in_string, escape_next)
+
     return errors
 
 
 def check_editorconfig(json_file):
     """Check if JSON file adheres to .editorconfig rules."""
     errors = []
-    
+
     try:
         with open(json_file, 'rb') as f:
             content = f.read()
-        
+
         # Check charset (UTF-8)
         try:
             text = content.decode('utf-8')
@@ -273,20 +251,20 @@ def check_editorconfig(json_file):
             errors.append("ERROR: File is not UTF-8 encoded")
             print('\n'.join(errors))
             return False
-        
+
         # Check end_of_line (LF)
         if b'\r\n' in content:
             errors.append("ERROR: File contains CRLF line endings (should be LF)")
         elif b'\r' in content:
             errors.append("ERROR: File contains CR line endings (should be LF)")
-        
+
         # Check insert_final_newline
         if not content.endswith(b'\n'):
             errors.append("ERROR: File does not end with a newline")
-        
+
         # Check trim_trailing_whitespace and indent_style (tabs)
         lines = text.split('\n')
-        
+
         # Parse JSON to get entry information for error messages
         try:
             data = json.loads(text)
@@ -294,21 +272,21 @@ def check_editorconfig(json_file):
         except (json.JSONDecodeError, Exception):
             data = None
             is_array = False
-        
+
         # Track current entry while checking each line
         depth = 0
         in_string = False
         escape_next = False
         current_entry_index = None
         current_entry_title = None
-        
+
         for i, line in enumerate(lines, 1):
             # Skip the final empty line (result of file ending with \n)
             if i == len(lines) and line == '':
                 continue
-            
+
             stripped = line.strip()
-            
+
             # Track which entry we're in based on depth
             if is_array and data and depth == 1 and (stripped == '{' or stripped.startswith('{')):
                 current_entry_index = 0 if current_entry_index is None else current_entry_index + 1
@@ -319,7 +297,7 @@ def check_editorconfig(json_file):
             elif depth == 0:
                 current_entry_index = None
                 current_entry_title = None
-            
+
             # Check trailing whitespace
             if line.rstrip() != line:
                 if current_entry_index is not None and current_entry_title:
@@ -328,7 +306,7 @@ def check_editorconfig(json_file):
                     errors.append(f"ERROR: Entry #{current_entry_index}: Line {i} has trailing whitespace")
                 else:
                     errors.append(f"ERROR: Line {i} has trailing whitespace")
-            
+
             # Check for spaces used for indentation (should be tabs)
             if line.startswith(' '):
                 if current_entry_index is not None and current_entry_title:
@@ -337,57 +315,27 @@ def check_editorconfig(json_file):
                     errors.append(f"ERROR: Entry #{current_entry_index}: Line {i} uses spaces for indentation (should use tabs)")
                 else:
                     errors.append(f"ERROR: Line {i} uses spaces for indentation (should use tabs)")
-            
-            # Update depth for entry tracking
-            if not stripped:
-                continue
-            
-            line_in_string = in_string
-            line_escape_next = escape_next
-            open_count = 0
-            close_count = 0
-            
-            for char in stripped:
-                if line_escape_next:
-                    line_escape_next = False
-                    continue
-                
-                if char == '\\':
-                    line_escape_next = True
-                    continue
-                
-                if char == '"':
-                    line_in_string = not line_in_string
-                    continue
-                
-                if not line_in_string:
-                    if char == '{' or char == '[':
-                        open_count += 1
-                    elif char == '}' or char == ']':
-                        close_count += 1
-            
-            in_string = line_in_string
-            escape_next = line_escape_next
-            depth += (open_count - close_count)
-            if depth < 0:
-                depth = 0
-        
+
+            # Update depth for the next line
+            if stripped:
+                depth, in_string, escape_next = _update_depth(stripped, depth, in_string, escape_next)
+
         # Check JSON structural indentation
         structural_errors = check_json_structural_indentation(text, lines)
         errors.extend(structural_errors)
-        
+
         # Check for Unicode escape sequences (if JSON is valid)
         if data is not None:
             unicode_errors = check_unicode_escapes(text, data)
             errors.extend(unicode_errors)
-        
+
         if errors:
             print('\n'.join(errors))
             return False
-        
+
         print("SUCCESS: File adheres to .editorconfig rules")
         return True
-    
+
     except FileNotFoundError:
         print(f"ERROR: File '{json_file}' not found")
         return False
@@ -399,6 +347,6 @@ if __name__ == "__main__":
     if len(sys.argv) != 2:
         print("Usage: check_editorconfig.py <json_file>")
         sys.exit(1)
-    
+
     success = check_editorconfig(sys.argv[1])
     sys.exit(0 if success else 1)


### PR DESCRIPTION
The editorconfig check was taking 2+ minutes on every PR because it was scanning backward through the whole file for every entry it found
— swapped that for a simple counter and it now runs in under a second.

Also fixed two smaller bugs while I was in there:
- `check_unicode_escapes` was falsely flagging valid UTF-8 characters (like `é` or `ã`) as violations due to using `ensure_ascii=True` internally
- `check_duplicates` wasn't actually lowercasing URLs despite the docstring saying it would, so `HTTPS://GITHUB.COM/x` and `https://github.com/x` weren't being caught as duplicates

All existing checks still pass on `_data/tools.json`.
